### PR TITLE
fix: reuse msgspec Encoder and Decoder instances

### DIFF
--- a/advanced_alchemy/config/engine.py
+++ b/advanced_alchemy/config/engine.py
@@ -15,23 +15,25 @@ if TYPE_CHECKING:
     from advanced_alchemy.config.types import EmptyType
 
 try:
-    from msgspec.json import decode as decode_json
-    from msgspec.json import encode as _encode_json
+    from msgspec.json import Decoder, Encoder
+
+    encoder, decoder = Encoder(), Decoder()
+    decode_json = decoder.decode
 
     def encode_json(data: Any) -> str:
-        return _encode_json(data).decode("utf-8")
+        return encoder.encode(data).decode("utf-8")
 
 except ImportError:
     try:
-        from orjson import dumps as _encode_json  # type: ignore[no-redef]
+        from orjson import dumps as _encode_json
         from orjson import loads as decode_json  # type: ignore[no-redef]
 
         def encode_json(data: Any) -> str:
-            return _encode_json(data).decode("utf-8")
+            return _encode_json(data).decode("utf-8")  # type: ignore[no-any-return]
 
     except ImportError:
         from json import dumps as encode_json  # type: ignore[assignment]
-        from json import loads as decode_json  # type: ignore[no-redef]
+        from json import loads as decode_json  # type: ignore[assignment]
 
 __all__ = ("EngineConfig",)
 


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Jolt's Code of Conduct](https://github.com/jolt-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Jolt's contribution guidelines](https://github.com/jolt-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- This PR reuses the `Encoder` and `Decoder` instances when using `msgspec` as the JSON serializer/deserializer.