### PR TITLE
fix: correct reference to plugin for litestar

### DIFF
--- a/advanced_alchemy/extensions/litestar/alembic.py
+++ b/advanced_alchemy/extensions/litestar/alembic.py
@@ -25,5 +25,5 @@ def get_database_migration_plugin(app: Litestar) -> SQLAlchemyInitPlugin:
 class AlembicCommands(_AlembicCommands):
     def __init__(self, app: Litestar) -> None:
         self._app = app
-        self.plugin_config = get_database_migration_plugin(self._app)._config  # noqa: SLF001
+        self.sqlalchemy_config = get_database_migration_plugin(self._app)._config  # noqa: SLF001
         self.config = self._get_alembic_command_config()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ license = {text = "MIT"}
 name = "advanced_alchemy"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "0.2.0"
+version = "0.2.1"
 
 [project.urls]
 Changelog = "https://docs.advanced-alchemy.jolt.rs/latest/changelog"


### PR DESCRIPTION
This fix corrects the reference to the `sqlalchemy_config` for Litestar integration.