### PR TITLE
msgspec missing from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
   "sqlalchemy>=2.0.20",
   "alembic>=1.12.0",
+  "msgspec>=0.18.2",
   "typing_extensions",
 ]
 description = "Ready-to-go SQLAlchemy concoctions."


### PR DESCRIPTION
msgspec is imported from the library, but currently declared as optional in pyproject.