### PR TITLE
feat: configurable autocommit handler factory function for Litestar plugin

### DIFF
--- a/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
@@ -55,9 +55,9 @@ def autocommit_handler_maker(
 ) -> Callable[[Message, Scope], Coroutine[Any, Any, None]]:
     """Set up the handler to issue a transactin commit or rollback based on specified status codes
     Args:
-        commit_on_redirect: issue a commit when the response status is a redirect (3XX)
-        extra_commit_statuses: a set of additional status codes that trigger a commit
-        extra_rollback_statuses: a set of additional status codes that trigger a rollback
+        commit_on_redirect: Issue a commit when the response status is a redirect (``3XX``)
+        extra_commit_statuses: A set of additional status codes that trigger a commit
+        extra_rollback_statuses: A set of additional status codes that trigger a rollback
 
     Returns:
         The handler callable

--- a/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
@@ -48,7 +48,7 @@ async def default_before_send_handler(message: Message, scope: Scope) -> None:
         delete_litestar_scope_state(scope, SESSION_SCOPE_KEY)
 
 
-def autocommit_handler(
+def autocommit_handler_maker(
     commit_on_redirect: bool = False,
     extra_commit_statuses: set[int] | None = None,
     extra_rollback_statuses: set[int] | None = None,
@@ -102,7 +102,7 @@ def autocommit_handler(
     return handler
 
 
-autocommit_before_send_handler = autocommit_handler()
+autocommit_before_send_handler = autocommit_handler_maker()
 
 
 @dataclass

--- a/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
@@ -48,7 +48,7 @@ async def default_before_send_handler(message: Message, scope: Scope) -> None:
         delete_litestar_scope_state(scope, SESSION_SCOPE_KEY)
 
 
-def auto_commit_handler(
+def autocommit_handler(
     commit_on_redirect: bool = False,
     extra_commit_statuses: set[int] | None = None,
     extra_rollback_statuses: set[int] | None = None,
@@ -101,7 +101,7 @@ def auto_commit_handler(
     return handler
 
 
-autocommit_before_send_handler = auto_commit_handler()
+autocommit_before_send_handler = autocommit_handler()
 
 
 @dataclass

--- a/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
@@ -72,6 +72,8 @@ def autocommit_handler(
         msg = "Extra rollback statuses and commit statuses must not share any status codes"
         raise ValueError(msg)
 
+    commit_range = range(200, 300 if not commit_on_redirect else 400)
+
     async def handler(message: Message, scope: Scope) -> None:
         """Handle commit/rollback, closing and cleaning up sessions before sending.
 
@@ -85,7 +87,6 @@ def autocommit_handler(
         session = cast("AsyncSession | None", get_litestar_scope_state(scope, SESSION_SCOPE_KEY))
         try:
             if session is not None and message["type"] == HTTP_RESPONSE_START:
-                commit_range = range(200, 300 if not commit_on_redirect else 400)
                 if (
                     cast("HTTPResponseStartEvent", message)["status"] in commit_range
                     or message["status"] in extra_commit_statuses

--- a/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/config/asyncio.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, cast
 
 from litestar.constants import HTTP_RESPONSE_START
-from litestar.status_codes import HTTP_200_OK, HTTP_300_MULTIPLE_CHOICES, HTTP_302_FOUND, HTTP_303_SEE_OTHER
 from litestar.utils import delete_litestar_scope_state, get_litestar_scope_state, set_litestar_scope_state
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -16,7 +15,7 @@ from advanced_alchemy.extensions.litestar.plugins.init.config.common import (
 from advanced_alchemy.extensions.litestar.plugins.init.config.engine import EngineConfig
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Coroutine
 
     from litestar import Litestar
     from litestar.datastructures.state import State
@@ -49,29 +48,60 @@ async def default_before_send_handler(message: Message, scope: Scope) -> None:
         delete_litestar_scope_state(scope, SESSION_SCOPE_KEY)
 
 
-async def autocommit_before_send_handler(message: Message, scope: Scope) -> None:
-    """Handle commit/rollback, closing and cleaning up sessions before sending.
-
+def auto_commit_handler(
+    commit_on_redirect: bool = False,
+    extra_commit_statuses: set[int] | None = None,
+    extra_rollback_statuses: set[int] | None = None,
+) -> Callable[[Message, Scope], Coroutine[Any, Any, None]]:
+    """Set up the handler to issue a transactin commit or rollback based on specified status codes
     Args:
-        message: ASGI-``Message``
-        scope: An ASGI-``Scope``
+        commit_on_redirect: issue a commit when the response status is a redirect (3XX)
+        extra_commit_statuses: a set of additional status codes that trigger a commit
+        extra_rollback_statuses: a set of additional status codes that trigger a rollback
 
     Returns:
-        None
+        The handler callable
     """
-    session = cast("AsyncSession | None", get_litestar_scope_state(scope, SESSION_SCOPE_KEY))
-    try:
-        if session is not None and message["type"] == HTTP_RESPONSE_START:
-            if (
-                HTTP_200_OK <= cast("HTTPResponseStartEvent", message)["status"] < HTTP_300_MULTIPLE_CHOICES
-            ) or message["status"] in {HTTP_302_FOUND, HTTP_303_SEE_OTHER}:
-                await session.commit()
-            else:
-                await session.rollback()
-    finally:
-        if session and message["type"] in SESSION_TERMINUS_ASGI_EVENTS:
-            await session.close()
-            delete_litestar_scope_state(scope, SESSION_SCOPE_KEY)
+    if extra_commit_statuses is None:
+        extra_commit_statuses = set()
+
+    if extra_rollback_statuses is None:
+        extra_rollback_statuses = set()
+
+    if len(extra_commit_statuses & extra_rollback_statuses) > 0:
+        msg = "Extra rollback statuses and commit statuses must not share any status codes"
+        raise ValueError(msg)
+
+    async def handler(message: Message, scope: Scope) -> None:
+        """Handle commit/rollback, closing and cleaning up sessions before sending.
+
+        Args:
+            message: ASGI-``Message``
+            scope: An ASGI-``Scope``
+
+        Returns:
+            None
+        """
+        session = cast("AsyncSession | None", get_litestar_scope_state(scope, SESSION_SCOPE_KEY))
+        try:
+            if session is not None and message["type"] == HTTP_RESPONSE_START:
+                commit_range = range(200, 300 if not commit_on_redirect else 400)
+                if (
+                    cast("HTTPResponseStartEvent", message)["status"] in commit_range
+                    or message["status"] in extra_commit_statuses
+                ) and message["status"] not in extra_rollback_statuses:
+                    await session.commit()
+                else:
+                    await session.rollback()
+        finally:
+            if session and message["type"] in SESSION_TERMINUS_ASGI_EVENTS:
+                await session.close()
+                delete_litestar_scope_state(scope, SESSION_SCOPE_KEY)
+
+    return handler
+
+
+autocommit_before_send_handler = auto_commit_handler()
 
 
 @dataclass

--- a/tests/unit/test_extensions/test_litestar/test_init_plugin/test_asyncio.py
+++ b/tests/unit/test_extensions/test_litestar/test_init_plugin/test_asyncio.py
@@ -58,25 +58,6 @@ async def test_before_send_handler_success_response(create_scope: Callable[..., 
     mock_session.commit.assert_awaited_once()
 
 
-async def test_before_send_handler_redirect_response(create_scope: Callable[..., Scope]) -> None:
-    """Test that the session is committed given a success response."""
-    config = SQLAlchemyAsyncConfig(
-        connection_string="sqlite+aiosqlite://",
-        before_send_handler=autocommit_before_send_handler,
-    )
-    app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
-    mock_session = MagicMock(spec=AsyncSession)
-    http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
-    http_response_start: HTTPResponseStartEvent = {
-        "type": "http.response.start",
-        "status": random.randint(302, 303),
-        "headers": {},
-    }
-    await autocommit_before_send_handler(http_response_start, http_scope)
-    mock_session.commit.assert_awaited_once()
-
-
 async def test_before_send_handler_error_response(create_scope: Callable[..., Scope]) -> None:
     """Test that the session is committed given a success response."""
     config = SQLAlchemyAsyncConfig(
@@ -87,10 +68,9 @@ async def test_before_send_handler_error_response(create_scope: Callable[..., Sc
     mock_session = MagicMock(spec=AsyncSession)
     http_scope = create_scope(app=app)
     set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
-    status_codes = [i for i in range(300, 600) if i not in {302, 303}]
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
-        "status": random.choice(status_codes),
+        "status": random.randint(300, 599),
         "headers": {},
     }
     await autocommit_before_send_handler(http_response_start, http_scope)

--- a/tests/unit/test_extensions/test_litestar/test_init_plugin/test_asyncio.py
+++ b/tests/unit/test_extensions/test_litestar/test_init_plugin/test_asyncio.py
@@ -58,7 +58,7 @@ async def test_before_send_handler_success_response(create_scope: Callable[..., 
     mock_session.commit.assert_awaited_once()
 
 
-async def test_before_send_handler_error_response(create_scope: Callable[..., Scope]) -> None:
+async def test_before_send_handler_redirect_response(create_scope: Callable[..., Scope]) -> None:
     """Test that the session is committed given a success response."""
     config = SQLAlchemyAsyncConfig(
         connection_string="sqlite+aiosqlite://",
@@ -70,7 +70,27 @@ async def test_before_send_handler_error_response(create_scope: Callable[..., Sc
     set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
-        "status": random.randint(300, 599),
+        "status": random.randint(302, 303),
+        "headers": {},
+    }
+    await autocommit_before_send_handler(http_response_start, http_scope)
+    mock_session.commit.assert_awaited_once()
+
+
+async def test_before_send_handler_error_response(create_scope: Callable[..., Scope]) -> None:
+    """Test that the session is committed given a success response."""
+    config = SQLAlchemyAsyncConfig(
+        connection_string="sqlite+aiosqlite://",
+        before_send_handler=autocommit_before_send_handler,
+    )
+    app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
+    mock_session = MagicMock(spec=AsyncSession)
+    http_scope = create_scope(app=app)
+    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    status_codes = [i for i in range(300, 600) if i not in {302, 303}]
+    http_response_start: HTTPResponseStartEvent = {
+        "type": "http.response.start",
+        "status": random.choice(status_codes),
         "headers": {},
     }
     await autocommit_before_send_handler(http_response_start, http_scope)


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Jolt's Code of Conduct](https://github.com/jolt-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Jolt's contribution guidelines](https://github.com/jolt-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
Introduction of a new factory function `autocommit_handler` to create handlers that supports:
- handling all redirects (3XX) with performing a commit
- specifying custom sets of status codes for commit and/or rollback

This might be desirable for MPAs, where it is quite common to use the [PRG pattern](https://en.wikipedia.org/wiki/Post/Redirect/Get) - after a successful form submission, a redirect response is issued to prevent multiple submission (by for example reloading the page).
It also gives more flexibility with defining when the transaction should be rolled back or committed.

~~This change is breaking for applications, that rely on the old behaviour, i.e. having the transaction rolled back upon any redirect.~~
