### PR TITLE
fix: CollectionFilter returns all entries if values is empty

### DIFF
--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1106,6 +1106,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         statement: StatementLambdaElement,
     ) -> StatementLambdaElement:
         if not values:
+            statement += lambda s: s.where(text("1=-1"))
             return statement
         field = get_instrumented_attr(self.model_type, field_name)
         statement += lambda s: s.where(field.in_(values))

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -1107,6 +1107,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         statement: StatementLambdaElement,
     ) -> StatementLambdaElement:
         if not values:
+            statement += lambda s: s.where(text("1=-1"))
             return statement
         field = get_instrumented_attr(self.model_type, field_name)
         statement += lambda s: s.where(field.in_(values))

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1033,6 +1033,9 @@ async def test_repo_filter_collection(
     existing_obj = await maybe_async(author_repo.list(CollectionFilter(field_name="id", values=[second_author_id])))
     assert existing_obj[0].name == "Leo Tolstoy"
 
+    no_obj = await maybe_async(author_repo.list(CollectionFilter(field_name="id", values=[])))
+    assert no_obj is None
+
 
 async def test_repo_filter_not_in_collection(
     author_repo: AuthorRepository,

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1033,6 +1033,10 @@ async def test_repo_filter_collection(
     existing_obj = await maybe_async(author_repo.list(CollectionFilter(field_name="id", values=[second_author_id])))
     assert existing_obj[0].name == "Leo Tolstoy"
 
+
+async def test_repo_filter_no_obj_collection(
+    author_repo: AuthorRepository,
+) -> None:
     no_obj = await maybe_async(author_repo.list(CollectionFilter(field_name="id", values=[])))
     assert no_obj is None
 
@@ -1050,6 +1054,13 @@ async def test_repo_filter_not_in_collection(
         author_repo.list(NotInCollectionFilter(field_name="id", values=[second_author_id])),
     )
     assert existing_obj[0].name == "Agatha Christie"
+
+
+async def test_repo_filter_not_in_no_obj_collection(
+    author_repo: AuthorRepository,
+) -> None:
+    existing_obj = await maybe_async(author_repo.list(NotInCollectionFilter(field_name="id", values=[])))
+    assert len(existing_obj) > 0
 
 
 async def test_repo_json_methods(

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, Any, Collection, Union, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -639,6 +639,23 @@ async def test_sqlalchemy_repo_list_with_collection_filter(
     mock_repo.statement.where.return_value = mock_repo.statement
     mocker.patch.object(mock_repo, "_filter_in_collection", return_value=mock_repo.statement)
     values = [1, 2, 3]
+    await maybe_async(mock_repo.list(CollectionFilter(field_name, values)))
+    assert mock_repo._filter_in_collection.call_count == 1
+    mock_repo._filter_in_collection.assert_called_with(field_name, values, statement=mock_repo.statement)
+
+
+async def test_sqlalchemy_repo_empty_list_with_collection_filter(
+    mock_repo: SQLAlchemyAsyncRepository,
+    monkeypatch: MonkeyPatch,
+    mock_repo_execute: AnyMock,
+    mocker: MockerFixture,
+) -> None:
+    """Test behavior of list operation given CollectionFilter."""
+    field_name = "id"
+    mock_repo_execute.return_value = MagicMock()
+    mock_repo.statement.where.return_value = mock_repo.statement
+    mocker.patch.object(mock_repo, "_filter_in_collection", return_value=mock_repo.statement)
+    values: Collection[Any] = []
     await maybe_async(mock_repo.list(CollectionFilter(field_name, values)))
     assert mock_repo._filter_in_collection.call_count == 1
     mock_repo._filter_in_collection.assert_called_with(field_name, values, statement=mock_repo.statement)


### PR DESCRIPTION
Fixes #51

Bug: CollectionFilter returns all entries if values is empty

a simple `1=-1` is appended into the `where` clause when an empty list is passed into the `in` statement.