### PR TITLE
feat: prefer `ANY` over `IN` for `postgres`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: unasyncd
         additional_dependencies: ["ruff"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.292"
+    rev: "v0.1.0"
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -34,7 +34,7 @@ repos:
       - id: codespell
         exclude: "pdm.lock|examples/us_state_lookup.json"
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.10.0
     hooks:
       - id: black
         args: [--config=./pyproject.toml]
@@ -70,6 +70,6 @@ repos:
             "litestar[cli]",
           ]
   - repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: "v0.7.0"
+    rev: "v0.8.1"
     hooks:
       - id: sphinx-lint

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1045,7 +1045,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         statement += lambda s: s.limit(limit).offset(offset)
         return statement
 
-    def _apply_filters(  # noqa: PLR0912, C901
+    def _apply_filters(
         self,
         *filters: FilterTypes | ColumnElement[bool],
         apply_pagination: bool = True,

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -53,6 +53,9 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
     model_type: type[ModelT]
     id_attribute: Any = "id"
     match_fields: list[str] | str | None = None
+    _prefer_any_clause: bool = False
+    prefer_any_clause_engines: tuple[str] | None = ("postgresql",)
+    """Database engines that prefer to use ``where field.id = ANY(:1)`` instead of ``where field.id IN (...)``."""
 
     def __init__(
         self,
@@ -93,6 +96,9 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             msg = "Session improperly configure"
             raise ValueError(msg)
         self._dialect = self.session.bind.dialect
+        self._prefer_any_clause = any(
+            self._dialect.name == engine_type for engine_type in self.prefer_any_clause_engines or ()
+        )
 
     @classmethod
     def get_id_attribute_value(cls, item: ModelT | type[ModelT], id_attribute: str | None = None) -> Any:
@@ -255,6 +261,8 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
                 id_attribute if id_attribute is not None else self.id_attribute,
             )
             instances: list[ModelT] = []
+            if self._prefer_any_clause:
+                chunk_size = len(item_ids) + 1
             chunk_size = self._get_insertmanyvalues_max_parameters(chunk_size)
             for idx in range(0, len(item_ids), chunk_size):
                 chunk = item_ids[idx : min(idx + chunk_size, len(item_ids))]
@@ -325,8 +333,8 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             return lambda_stmt(lambda: statement)
         return self.statement if statement is None else statement
 
-    @staticmethod
     def _get_delete_many_statement(
+        self,
         model_type: type[ModelT],
         id_attribute: InstrumentedAttribute,
         id_chunk: list[Any],
@@ -337,7 +345,10 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             statement = lambda_stmt(lambda: delete(model_type))
         elif statement_type == "select":
             statement = lambda_stmt(lambda: select(model_type))
-        statement += lambda s: s.where(id_attribute.in_(id_chunk))
+        if self._prefer_any_clause:
+            statement += lambda s: s.where(id_chunk=id_attribute.any_())
+        else:
+            statement += lambda s: s.where(id_attribute.in_(id_chunk))
         if supports_returning and statement_type != "select":
             statement += lambda s: s.returning(model_type)
         return statement
@@ -1034,7 +1045,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         statement += lambda s: s.limit(limit).offset(offset)
         return statement
 
-    def _apply_filters(
+    def _apply_filters(  # noqa: PLR0912, C901
         self,
         *filters: FilterTypes | ColumnElement[bool],
         apply_pagination: bool = True,
@@ -1073,9 +1084,26 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
                 )
 
             elif isinstance(filter_, (NotInCollectionFilter,)):
-                statement = self._filter_not_in_collection(filter_.field_name, filter_.values, statement=statement)
+                if filter_.values is not None:  # noqa: PD011
+                    if self._prefer_any_clause:
+                        statement = self._filter_not_any_collection(
+                            filter_.field_name,
+                            filter_.values,
+                            statement=statement,
+                        )
+                    else:
+                        statement = self._filter_not_in_collection(
+                            filter_.field_name,
+                            filter_.values,
+                            statement=statement,
+                        )
+
             elif isinstance(filter_, (CollectionFilter,)):
-                statement = self._filter_in_collection(filter_.field_name, filter_.values, statement=statement)
+                if filter_.values is not None:  # noqa: PD011
+                    if self._prefer_any_clause:
+                        statement = self._filter_any_collection(filter_.field_name, filter_.values, statement=statement)
+                    else:
+                        statement = self._filter_in_collection(filter_.field_name, filter_.values, statement=statement)
             elif isinstance(filter_, (OrderBy,)):
                 statement = self._order_by(statement, filter_.field_name, sort_desc=filter_.sort_order == "desc")
             elif isinstance(filter_, (SearchFilter,)):
@@ -1122,6 +1150,31 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             return statement
         field = get_instrumented_attr(self.model_type, field_name)
         statement += lambda s: s.where(field.notin_(values))
+        return statement
+
+    def _filter_any_collection(
+        self,
+        field_name: str | InstrumentedAttribute,
+        values: abc.Collection[Any],
+        statement: StatementLambdaElement,
+    ) -> StatementLambdaElement:
+        if not values:
+            statement += lambda s: s.where(text("1=-1"))
+            return statement
+        field = get_instrumented_attr(self.model_type, field_name)
+        statement += lambda s: s.where(values == field.any_())
+        return statement
+
+    def _filter_not_any_collection(
+        self,
+        field_name: str | InstrumentedAttribute,
+        values: abc.Collection[Any],
+        statement: StatementLambdaElement,
+    ) -> StatementLambdaElement:
+        if not values:
+            return statement
+        field = get_instrumented_attr(self.model_type, field_name)
+        statement += lambda s: s.where(values != field.any_())
         return statement
 
     def _filter_on_datetime_field(

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     Select,
     StatementLambdaElement,
     TextClause,
+    any_,
     delete,
     lambda_stmt,
     over,
@@ -344,7 +345,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         elif statement_type == "select":
             statement = lambda_stmt(lambda: select(model_type))
         if self._prefer_any:
-            statement += lambda s: s.where(id_chunk=id_attribute.any_())
+            statement += lambda s: s.where(any_(id_chunk) == id_attribute)  # type: ignore[arg-type]
         else:
             statement += lambda s: s.where(id_attribute.in_(id_chunk))
         if supports_returning and statement_type != "select":
@@ -1160,7 +1161,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             statement += lambda s: s.where(text("1=-1"))
             return statement
         field = get_instrumented_attr(self.model_type, field_name)
-        statement += lambda s: s.where(values == field.any_())
+        statement += lambda s: s.where(any_(values) == field)  # type: ignore[arg-type]
         return statement
 
     def _filter_not_any_collection(
@@ -1172,7 +1173,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         if not values:
             return statement
         field = get_instrumented_attr(self.model_type, field_name)
-        statement += lambda s: s.where(values != field.any_())
+        statement += lambda s: s.where(any_(values) != field)  # type: ignore[arg-type]
         return statement
 
     def _filter_on_datetime_field(

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -56,7 +56,12 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
     match_fields: list[str] | str | None = None
     _prefer_any_clause: bool = False
     prefer_any_clause_engines: tuple[str] | None = ("postgresql",)
-    """Database engines that prefer to use ``where field.id = ANY(:1)`` instead of ``where field.id IN (...)``."""
+    """Prefer ``ANY`` over ``IN``
+
+    Some database engines are optimized for the ``ANY`` operation over ``IN``.
+
+    When possible, utilize``where field.id = ANY(:1)`` instead of ``where field.id IN (...)``.
+    """
 
     def __init__(
         self,
@@ -1046,7 +1051,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         statement += lambda s: s.limit(limit).offset(offset)
         return statement
 
-    def _apply_filters(  # noqa: C901, PLR0912
+    def _apply_filters(
         self,
         *filters: FilterTypes | ColumnElement[bool],
         apply_pagination: bool = True,

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Select,
     StatementLambdaElement,
     TextClause,
+    any_,
     delete,
     lambda_stmt,
     over,
@@ -345,7 +346,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         elif statement_type == "select":
             statement = lambda_stmt(lambda: select(model_type))
         if self._prefer_any:
-            statement += lambda s: s.where(id_chunk=id_attribute.any_())
+            statement += lambda s: s.where(any_(id_chunk) == id_attribute)  # type: ignore[arg-type]
         else:
             statement += lambda s: s.where(id_attribute.in_(id_chunk))
         if supports_returning and statement_type != "select":
@@ -1161,7 +1162,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             statement += lambda s: s.where(text("1=-1"))
             return statement
         field = get_instrumented_attr(self.model_type, field_name)
-        statement += lambda s: s.where(values == field.any_())
+        statement += lambda s: s.where(any_(values) == field)  # type: ignore[arg-type]
         return statement
 
     def _filter_not_any_collection(
@@ -1173,7 +1174,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         if not values:
             return statement
         field = get_instrumented_attr(self.model_type, field_name)
-        statement += lambda s: s.where(values != field.any_())
+        statement += lambda s: s.where(any_(values) != field)  # type: ignore[arg-type]
         return statement
 
     def _filter_on_datetime_field(

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -54,14 +54,9 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
     model_type: type[ModelT]
     id_attribute: Any = "id"
     match_fields: list[str] | str | None = None
-    _prefer_any_clause: bool = False
-    prefer_any_clause_engines: tuple[str] | None = ("postgresql",)
-    """Prefer ``ANY`` over ``IN``
-
-    Some database engines are optimized for the ``ANY`` operation over ``IN``.
-
-    When possible, utilize``where field.id = ANY(:1)`` instead of ``where field.id IN (...)``.
-    """
+    _prefer_any: bool = False
+    prefer_any_dialects: tuple[str] | None = ("postgresql",)
+    """List of dialects that prefer to use ``field.id = ANY(:1)`` instead of ``field.id IN (...)``."""
 
     def __init__(
         self,
@@ -102,9 +97,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             msg = "Session improperly configure"
             raise ValueError(msg)
         self._dialect = self.session.bind.dialect
-        self._prefer_any_clause = any(
-            self._dialect.name == engine_type for engine_type in self.prefer_any_clause_engines or ()
-        )
+        self._prefer_any = any(self._dialect.name == engine_type for engine_type in self.prefer_any_dialects or ())
 
     @classmethod
     def get_id_attribute_value(cls, item: ModelT | type[ModelT], id_attribute: str | None = None) -> Any:
@@ -267,7 +260,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
                 id_attribute if id_attribute is not None else self.id_attribute,
             )
             instances: list[ModelT] = []
-            if self._prefer_any_clause:
+            if self._prefer_any:
                 chunk_size = len(item_ids) + 1
             chunk_size = self._get_insertmanyvalues_max_parameters(chunk_size)
             for idx in range(0, len(item_ids), chunk_size):
@@ -351,7 +344,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             statement = lambda_stmt(lambda: delete(model_type))
         elif statement_type == "select":
             statement = lambda_stmt(lambda: select(model_type))
-        if self._prefer_any_clause:
+        if self._prefer_any:
             statement += lambda s: s.where(id_chunk=id_attribute.any_())
         else:
             statement += lambda s: s.where(id_attribute.in_(id_chunk))
@@ -1091,7 +1084,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
 
             elif isinstance(filter_, (NotInCollectionFilter,)):
                 if filter_.values is not None:  # noqa: PD011
-                    if self._prefer_any_clause:
+                    if self._prefer_any:
                         statement = self._filter_not_any_collection(
                             filter_.field_name,
                             filter_.values,
@@ -1106,7 +1099,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
 
             elif isinstance(filter_, (CollectionFilter,)):
                 if filter_.values is not None:  # noqa: PD011
-                    if self._prefer_any_clause:
+                    if self._prefer_any:
                         statement = self._filter_any_collection(filter_.field_name, filter_.values, statement=statement)
                     else:
                         statement = self._filter_in_collection(filter_.field_name, filter_.values, statement=statement)

--- a/pdm.lock
+++ b/pdm.lock
@@ -290,7 +290,7 @@ files = [
 
 [[package]]
 name = "black"
-version = "23.9.1"
+version = "23.10.0"
 requires_python = ">=3.8"
 summary = "The uncompromising code formatter."
 dependencies = [
@@ -303,28 +303,24 @@ dependencies = [
     "typing-extensions>=4.0.1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "black-23.9.1-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:d6bc09188020c9ac2555a498949401ab35bb6bf76d4e0f8ee251694664df6301"},
-    {file = "black-23.9.1-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:13ef033794029b85dfea8032c9d3b92b42b526f1ff4bf13b2182ce4e917f5100"},
-    {file = "black-23.9.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:75a2dc41b183d4872d3a500d2b9c9016e67ed95738a3624f4751a0cb4818fe71"},
-    {file = "black-23.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13a2e4a93bb8ca74a749b6974925c27219bb3df4d42fc45e948a5d9feb5122b7"},
-    {file = "black-23.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:adc3e4442eef57f99b5590b245a328aad19c99552e0bdc7f0b04db6656debd80"},
-    {file = "black-23.9.1-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:8431445bf62d2a914b541da7ab3e2b4f3bc052d2ccbf157ebad18ea126efb91f"},
-    {file = "black-23.9.1-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:8fc1ddcf83f996247505db6b715294eba56ea9372e107fd54963c7553f2b6dfe"},
-    {file = "black-23.9.1-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:7d30ec46de88091e4316b17ae58bbbfc12b2de05e069030f6b747dfc649ad186"},
-    {file = "black-23.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031e8c69f3d3b09e1aa471a926a1eeb0b9071f80b17689a655f7885ac9325a6f"},
-    {file = "black-23.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:538efb451cd50f43aba394e9ec7ad55a37598faae3348d723b59ea8e91616300"},
-    {file = "black-23.9.1-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:638619a559280de0c2aa4d76f504891c9860bb8fa214267358f0a20f27c12948"},
-    {file = "black-23.9.1-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:a732b82747235e0542c03bf352c126052c0fbc458d8a239a94701175b17d4855"},
-    {file = "black-23.9.1-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:cf3a4d00e4cdb6734b64bf23cd4341421e8953615cba6b3670453737a72ec204"},
-    {file = "black-23.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf99f3de8b3273a8317681d8194ea222f10e0133a24a7548c73ce44ea1679377"},
-    {file = "black-23.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:14f04c990259576acd093871e7e9b14918eb28f1866f91968ff5524293f9c573"},
-    {file = "black-23.9.1-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:c619f063c2d68f19b2d7270f4cf3192cb81c9ec5bc5ba02df91471d0b88c4c5c"},
-    {file = "black-23.9.1-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:6a3b50e4b93f43b34a9d3ef00d9b6728b4a722c997c99ab09102fd5efdb88325"},
-    {file = "black-23.9.1-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:c46767e8df1b7beefb0899c4a95fb43058fa8500b6db144f4ff3ca38eb2f6393"},
-    {file = "black-23.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50254ebfa56aa46a9fdd5d651f9637485068a1adf42270148cd101cdf56e0ad9"},
-    {file = "black-23.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:403397c033adbc45c2bd41747da1f7fc7eaa44efbee256b53842470d4ac5a70f"},
-    {file = "black-23.9.1-py3-none-any.whl", hash = "sha256:6ccd59584cc834b6d127628713e4b6b968e5f79572da66284532525a042549f9"},
-    {file = "black-23.9.1.tar.gz", hash = "sha256:24b6b3ff5c6d9ea08a8888f6977eae858e1f340d7260cf56d70a49823236b62d"},
+    {file = "black-23.10.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:f8dc7d50d94063cdfd13c82368afd8588bac4ce360e4224ac399e769d6704e98"},
+    {file = "black-23.10.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:f20ff03f3fdd2fd4460b4f631663813e57dc277e37fb216463f3b907aa5a9bdd"},
+    {file = "black-23.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3d9129ce05b0829730323bdcb00f928a448a124af5acf90aa94d9aba6969604"},
+    {file = "black-23.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:960c21555be135c4b37b7018d63d6248bdae8514e5c55b71e994ad37407f45b8"},
+    {file = "black-23.10.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:30b78ac9b54cf87bcb9910ee3d499d2bc893afd52495066c49d9ee6b21eee06e"},
+    {file = "black-23.10.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:0e232f24a337fed7a82c1185ae46c56c4a6167fb0fe37411b43e876892c76699"},
+    {file = "black-23.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31946ec6f9c54ed7ba431c38bc81d758970dd734b96b8e8c2b17a367d7908171"},
+    {file = "black-23.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:c870bee76ad5f7a5ea7bd01dc646028d05568d33b0b09b7ecfc8ec0da3f3f39c"},
+    {file = "black-23.10.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:6901631b937acbee93c75537e74f69463adaf34379a04eef32425b88aca88a23"},
+    {file = "black-23.10.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:481167c60cd3e6b1cb8ef2aac0f76165843a374346aeeaa9d86765fe0dd0318b"},
+    {file = "black-23.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f74892b4b836e5162aa0452393112a574dac85e13902c57dfbaaf388e4eda37c"},
+    {file = "black-23.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:47c4510f70ec2e8f9135ba490811c071419c115e46f143e4dce2ac45afdcf4c9"},
+    {file = "black-23.10.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:76baba9281e5e5b230c9b7f83a96daf67a95e919c2dfc240d9e6295eab7b9204"},
+    {file = "black-23.10.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:a3c2ddb35f71976a4cfeca558848c2f2f89abc86b06e8dd89b5a65c1e6c0f22a"},
+    {file = "black-23.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db451a3363b1e765c172c3fd86213a4ce63fb8524c938ebd82919bf2a6e28c6a"},
+    {file = "black-23.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:7fb5fc36bb65160df21498d5a3dd330af8b6401be3f25af60c6ebfe23753f747"},
+    {file = "black-23.10.0-py3-none-any.whl", hash = "sha256:e223b731a0e025f8ef427dd79d8cd69c167da807f5710add30cdf131f13dd62e"},
+    {file = "black-23.10.0.tar.gz", hash = "sha256:31b9f87b277a68d0e99d2905edae08807c007973eaa609da5f0c62def6b7c0bd"},
 ]
 
 [[package]]
@@ -2470,27 +2466,27 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.0.292"
+version = "0.1.0"
 requires_python = ">=3.7"
 summary = "An extremely fast Python linter, written in Rust."
 files = [
-    {file = "ruff-0.0.292-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:02f29db018c9d474270c704e6c6b13b18ed0ecac82761e4fcf0faa3728430c96"},
-    {file = "ruff-0.0.292-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:69654e564342f507edfa09ee6897883ca76e331d4bbc3676d8a8403838e9fade"},
-    {file = "ruff-0.0.292-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c3c91859a9b845c33778f11902e7b26440d64b9d5110edd4e4fa1726c41e0a4"},
-    {file = "ruff-0.0.292-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4476f1243af2d8c29da5f235c13dca52177117935e1f9393f9d90f9833f69e4"},
-    {file = "ruff-0.0.292-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be8eb50eaf8648070b8e58ece8e69c9322d34afe367eec4210fdee9a555e4ca7"},
-    {file = "ruff-0.0.292-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:9889bac18a0c07018aac75ef6c1e6511d8411724d67cb879103b01758e110a81"},
-    {file = "ruff-0.0.292-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6bdfabd4334684a4418b99b3118793f2c13bb67bf1540a769d7816410402a205"},
-    {file = "ruff-0.0.292-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aa7c77c53bfcd75dbcd4d1f42d6cabf2485d2e1ee0678da850f08e1ab13081a8"},
-    {file = "ruff-0.0.292-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e087b24d0d849c5c81516ec740bf4fd48bf363cfb104545464e0fca749b6af9"},
-    {file = "ruff-0.0.292-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f160b5ec26be32362d0774964e218f3fcf0a7da299f7e220ef45ae9e3e67101a"},
-    {file = "ruff-0.0.292-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ac153eee6dd4444501c4bb92bff866491d4bfb01ce26dd2fff7ca472c8df9ad0"},
-    {file = "ruff-0.0.292-py3-none-musllinux_1_2_i686.whl", hash = "sha256:87616771e72820800b8faea82edd858324b29bb99a920d6aa3d3949dd3f88fb0"},
-    {file = "ruff-0.0.292-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b76deb3bdbea2ef97db286cf953488745dd6424c122d275f05836c53f62d4016"},
-    {file = "ruff-0.0.292-py3-none-win32.whl", hash = "sha256:e854b05408f7a8033a027e4b1c7f9889563dd2aca545d13d06711e5c39c3d003"},
-    {file = "ruff-0.0.292-py3-none-win_amd64.whl", hash = "sha256:f27282bedfd04d4c3492e5c3398360c9d86a295be00eccc63914438b4ac8a83c"},
-    {file = "ruff-0.0.292-py3-none-win_arm64.whl", hash = "sha256:7f67a69c8f12fbc8daf6ae6d36705037bde315abf8b82b6e1f4c9e74eb750f68"},
-    {file = "ruff-0.0.292.tar.gz", hash = "sha256:1093449e37dd1e9b813798f6ad70932b57cf614e5c2b5c51005bf67d55db33ac"},
+    {file = "ruff-0.1.0-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:87114e254dee35e069e1b922d85d4b21a5b61aec759849f393e1dbb308a00439"},
+    {file = "ruff-0.1.0-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:764f36d2982cc4a703e69fb73a280b7c539fd74b50c9ee531a4e3fe88152f521"},
+    {file = "ruff-0.1.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:65f4b7fb539e5cf0f71e9bd74f8ddab74cabdd673c6fb7f17a4dcfd29f126255"},
+    {file = "ruff-0.1.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:299fff467a0f163baa282266b310589b21400de0a42d8f68553422fa6bf7ee01"},
+    {file = "ruff-0.1.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0d412678bf205787263bb702c984012a4f97e460944c072fd7cfa2bd084857c4"},
+    {file = "ruff-0.1.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:a5391b49b1669b540924640587d8d24128e45be17d1a916b1801d6645e831581"},
+    {file = "ruff-0.1.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ee8cd57f454cdd77bbcf1e11ff4e0046fb6547cac1922cc6e3583ce4b9c326d1"},
+    {file = "ruff-0.1.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa7aeed7bc23861a2b38319b636737bf11cfa55d2109620b49cf995663d3e888"},
+    {file = "ruff-0.1.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b04cd4298b43b16824d9a37800e4c145ba75c29c43ce0d74cad1d66d7ae0a4c5"},
+    {file = "ruff-0.1.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7186ccf54707801d91e6314a016d1c7895e21d2e4cd614500d55870ed983aa9f"},
+    {file = "ruff-0.1.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d88adfd93849bc62449518228581d132e2023e30ebd2da097f73059900d8dce3"},
+    {file = "ruff-0.1.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ad2ccdb3bad5a61013c76a9c1240fdfadf2c7103a2aeebd7bcbbed61f363138f"},
+    {file = "ruff-0.1.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b77f6cfa72c6eb19b5cac967cc49762ae14d036db033f7d97a72912770fd8e1c"},
+    {file = "ruff-0.1.0-py3-none-win32.whl", hash = "sha256:480bd704e8af1afe3fd444cc52e3c900b936e6ca0baf4fb0281124330b6ceba2"},
+    {file = "ruff-0.1.0-py3-none-win_amd64.whl", hash = "sha256:a76ba81860f7ee1f2d5651983f87beb835def94425022dc5f0803108f1b8bfa2"},
+    {file = "ruff-0.1.0-py3-none-win_arm64.whl", hash = "sha256:45abdbdab22509a2c6052ecf7050b3f5c7d6b7898dc07e82869401b531d46da4"},
+    {file = "ruff-0.1.0.tar.gz", hash = "sha256:ad6b13824714b19c5f8225871cf532afb994470eecb74631cd3500fe817e6b3f"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,8 @@ classmethod-decorators = [
 ]
 
 [tool.ruff.per-file-ignores]
+"advanced_alchemy/repository/_async.py" = ['PLR0912', 'C901']
+"advanced_alchemy/service/_async.py" = ['PLR0912', 'C901']
 "tests/**/*.*" = [
   "A",
   "ARG",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,8 +193,7 @@ classmethod-decorators = [
 ]
 
 [tool.ruff.per-file-ignores]
-"advanced_alchemy/repository/_async.py" = ['PLR0912', 'C901']
-"advanced_alchemy/service/_async.py" = ['PLR0912', 'C901']
+"advanced_alchemy/repository/*.py" = ['PLR0912', 'C901']
 "tests/**/*.*" = [
   "A",
   "ARG",


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Jolt's Code of Conduct](https://github.com/jolt-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Jolt's contribution guidelines](https://github.com/jolt-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

This PR set the Postgres dialects to prefer to use an `ANY` instead of an `IN` for filtering a collection fo results.  

```sql
select id
from my_table
where id = ANY(:1)
```
instead of
```sql
select id
from my_table
where id in (:1, :2, :3, ...)
```

This has the additional benefit of allowing us to avoid hitting the max bind parameters values of the engine.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- 
