### PR TITLE
fix: do not set `id` with `item_id` when `None`

### DIFF
--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -114,7 +114,12 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         return getattr(item, id_attribute if id_attribute is not None else cls.id_attribute)
 
     @classmethod
-    def set_id_attribute_value(cls, item_id: Any, item: ModelT, id_attribute: str | None = None) -> ModelT:
+    def set_id_attribute_value(
+        cls,
+        item_id: Any,
+        item: ModelT,
+        id_attribute: str | None = None,
+    ) -> ModelT:
         """Return the ``item`` after the ID is set to the appropriate attribute.
 
         Args:

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -115,7 +115,12 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         return getattr(item, id_attribute if id_attribute is not None else cls.id_attribute)
 
     @classmethod
-    def set_id_attribute_value(cls, item_id: Any, item: ModelT, id_attribute: str | None = None) -> ModelT:
+    def set_id_attribute_value(
+        cls,
+        item_id: Any,
+        item: ModelT,
+        id_attribute: str | None = None,
+    ) -> ModelT:
         """Return the ``item`` after the ID is set to the appropriate attribute.
 
         Args:

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -313,7 +313,8 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             Updated representation.
         """
         data = await self.to_model(data, "update")
-        data = self.repository.set_id_attribute_value(item_id, data)
+        if item_id is not None:
+            data = self.repository.set_id_attribute_value(item_id, data)
         return await self.repository.update(
             data=data,
             attribute_names=attribute_names,

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Generic, Iterable, cast
 
+from sqlalchemy.orm import InstrumentedAttribute
+
 from advanced_alchemy.repository._util import model_from_dict
 from advanced_alchemy.repository.typing import ModelT
 
@@ -16,7 +18,6 @@ if TYPE_CHECKING:
 
     from sqlalchemy import Select, StatementLambdaElement
     from sqlalchemy.ext.asyncio import AsyncSession
-    from sqlalchemy.orm import InstrumentedAttribute
     from sqlalchemy.sql import ColumnElement
 
     from advanced_alchemy.filters import FilterTypes
@@ -313,8 +314,10 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
             Updated representation.
         """
         data = await self.to_model(data, "update")
+        if isinstance(id_attribute, InstrumentedAttribute):
+            id_attribute = cast("str", id_attribute.description)
         if item_id is not None:
-            data = self.repository.set_id_attribute_value(item_id, data)
+            data = self.repository.set_id_attribute_value(item_id=item_id, item=data, id_attribute=id_attribute)
         return await self.repository.update(
             data=data,
             attribute_names=attribute_names,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -314,7 +314,8 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             Updated representation.
         """
         data = self.to_model(data, "update")
-        data = self.repository.set_id_attribute_value(item_id, data)
+        if item_id is not None:
+            data = self.repository.set_id_attribute_value(item_id, data)
         return self.repository.update(
             data=data,
             attribute_names=attribute_names,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Generic, Iterable, cast
 
+from sqlalchemy.orm import InstrumentedAttribute, Session
+
 from advanced_alchemy.repository._util import model_from_dict
 from advanced_alchemy.repository.typing import ModelT
 
@@ -17,7 +19,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from sqlalchemy import Select, StatementLambdaElement
-    from sqlalchemy.orm import InstrumentedAttribute, Session
     from sqlalchemy.sql import ColumnElement
 
     from advanced_alchemy.filters import FilterTypes
@@ -314,8 +315,10 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
             Updated representation.
         """
         data = self.to_model(data, "update")
+        if isinstance(id_attribute, InstrumentedAttribute):
+            id_attribute = cast("str", id_attribute.description)
         if item_id is not None:
-            data = self.repository.set_id_attribute_value(item_id, data)
+            data = self.repository.set_id_attribute_value(item_id=item_id, item=data, id_attribute=id_attribute)
         return self.repository.update(
             data=data,
             attribute_names=attribute_names,

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -25,6 +25,7 @@ from advanced_alchemy.filters import (
     OrderBy,
     SearchFilter,
 )
+from advanced_alchemy.repository._util import get_instrumented_attr
 from tests import models_bigint, models_uuid
 from tests.helpers import maybe_async
 
@@ -1427,6 +1428,18 @@ async def test_service_update_method_no_item_id(author_service: AuthorService, f
     obj = await maybe_async(author_service.get(first_author_id))
     obj.name = "Updated Name2"
     updated_obj = await maybe_async(author_service.update(data=obj))
+    assert updated_obj.id == first_author_id
+    assert updated_obj.name == obj.name
+
+
+async def test_service_update_method_instrumented_attribute(
+    author_service: AuthorService,
+    first_author_id: Any,
+) -> None:
+    obj = await maybe_async(author_service.get(first_author_id))
+    id_attribute = get_instrumented_attr(author_service.repository.model_type, "id")
+    obj.name = "Updated Name2"
+    updated_obj = await maybe_async(author_service.update(data=obj, id_attribute=id_attribute, item_id=first_author_id))
     assert updated_obj.id == first_author_id
     assert updated_obj.name == obj.name
 

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1416,10 +1416,18 @@ async def test_service_exists_method(author_service: AuthorService, first_author
     assert exists
 
 
-async def test_service_update_method(author_service: AuthorService, first_author_id: Any) -> None:
+async def test_service_update_method_item_id(author_service: AuthorService, first_author_id: Any) -> None:
     obj = await maybe_async(author_service.get(first_author_id))
     obj.name = "Updated Name2"
     updated_obj = await maybe_async(author_service.update(item_id=first_author_id, data=obj))
+    assert updated_obj.name == obj.name
+
+
+async def test_service_update_method_no_item_id(author_service: AuthorService, first_author_id: Any) -> None:
+    obj = await maybe_async(author_service.get(first_author_id))
+    obj.name = "Updated Name2"
+    updated_obj = await maybe_async(author_service.update(data=obj))
+    assert updated_obj.id == first_author_id
     assert updated_obj.name == obj.name
 
 


### PR DESCRIPTION
This PR prevents the primary key from being overrwitten with `None` when using the service without the `item_id` parameter.