### PR TITLE
fix: service `exists` should use `exists` from repository

### DIFF
--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -87,7 +87,7 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT]):
         Returns:
             Representation of instance with identifier `item_id`.
         """
-        return await self.repository.count(*filters, **kwargs) > 0
+        return await self.repository.exists(*filters, **kwargs)
 
     async def get(
         self,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -88,7 +88,7 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT]):
         Returns:
             Representation of instance with identifier `item_id`.
         """
-        return self.repository.count(*filters, **kwargs) > 0
+        return self.repository.exists(*filters, **kwargs)
 
     def get(
         self,


### PR DESCRIPTION
The service should use the repository's implementation of `exists` instead of a new one with a `count`.

