### PR TITLE
feat: deprecate `get_or_create` in favor of `get_or_upsert`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ on:
       timeout:
         required: false
         type: number
-        default: 30
+        default: 45
 
 jobs:
   test:

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -34,6 +34,7 @@ from advanced_alchemy.filters import (
 from advanced_alchemy.operations import Merge
 from advanced_alchemy.repository._util import get_instrumented_attr, wrap_sqlalchemy_exception
 from advanced_alchemy.repository.typing import ModelT
+from advanced_alchemy.utils.deprecation import deprecated
 
 if TYPE_CHECKING:
     from collections import abc
@@ -440,6 +441,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
                 self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
+    @deprecated(version="0.3.5", alternative="SQLAlchemyAsyncRepository.get_or_upsert", kind="method")
     async def get_or_create(
         self,
         match_fields: list[str] | str | None = None,

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -36,6 +36,7 @@ from advanced_alchemy.filters import (
 from advanced_alchemy.operations import Merge
 from advanced_alchemy.repository._util import get_instrumented_attr, wrap_sqlalchemy_exception
 from advanced_alchemy.repository.typing import ModelT
+from advanced_alchemy.utils.deprecation import deprecated
 
 if TYPE_CHECKING:
     from collections import abc
@@ -441,6 +442,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
                 self._expunge(instance, auto_expunge=auto_expunge)
             return instance
 
+    @deprecated(version="0.3.5", alternative="SQLAlchemyAsyncRepository.get_or_upsert", kind="method")
     def get_or_create(
         self,
         match_fields: list[str] | str | None = None,

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -456,7 +456,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         """
         match_fields = match_fields or self.match_fields
         validated_model = await self.to_model(kwargs, "create")
-        return await self.repository.get_or_create(
+        return await self.repository.get_or_upsert(
             match_fields=match_fields,
             upsert=upsert,
             attribute_names=attribute_names,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -457,7 +457,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         """
         match_fields = match_fields or self.match_fields
         validated_model = self.to_model(kwargs, "create")
-        return self.repository.get_or_create(
+        return self.repository.get_or_upsert(
             match_fields=match_fields,
             upsert=upsert,
             attribute_names=attribute_names,

--- a/advanced_alchemy/utils/deprecation.py
+++ b/advanced_alchemy/utils/deprecation.py
@@ -28,9 +28,9 @@ def warn_deprecation(
     """Warn about a call to a (soon to be) deprecated function.
 
     Args:
-        version: Litestar version where the deprecation will occur
+        version: Advanced Alchemy version where the deprecation will occur
         deprecated_name: Name of the deprecated function
-        removal_in: Litestar version where the deprecated function will be removed
+        removal_in: Advanced Alchemy version where the deprecated function will be removed
         alternative: Name of a function that should be used instead
         info: Additional information
         pending: Use ``PendingDeprecationWarning`` instead of ``DeprecationWarning``
@@ -52,7 +52,7 @@ def warn_deprecation(
 
     parts.extend(
         (
-            f"Deprecated in litestar {version}",
+            f"Deprecated in advanced-alchemy {version}",
             f"This {kind} will be removed in {removal_in or 'the next major version'}",
         ),
     )

--- a/advanced_alchemy/utils/deprecation.py
+++ b/advanced_alchemy/utils/deprecation.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import inspect
+from functools import wraps
+from typing import Callable, Literal, TypeVar
+from warnings import warn
+
+from typing_extensions import ParamSpec
+
+__all__ = ("deprecated", "warn_deprecation")
+
+
+T = TypeVar("T")
+P = ParamSpec("P")
+DeprecatedKind = Literal["function", "method", "classmethod", "attribute", "property", "class", "parameter", "import"]
+
+
+def warn_deprecation(
+    version: str,
+    deprecated_name: str,
+    kind: DeprecatedKind,
+    *,
+    removal_in: str | None = None,
+    alternative: str | None = None,
+    info: str | None = None,
+    pending: bool = False,
+) -> None:
+    """Warn about a call to a (soon to be) deprecated function.
+
+    Args:
+        version: Litestar version where the deprecation will occur
+        deprecated_name: Name of the deprecated function
+        removal_in: Litestar version where the deprecated function will be removed
+        alternative: Name of a function that should be used instead
+        info: Additional information
+        pending: Use ``PendingDeprecationWarning`` instead of ``DeprecationWarning``
+        kind: Type of the deprecated thing
+    """
+    parts = []
+
+    if kind == "import":
+        access_type = "Import of"
+    elif kind in {"function", "method"}:
+        access_type = "Call to"
+    else:
+        access_type = "Use of"
+
+    if pending:
+        parts.append(f"{access_type} {kind} awaiting deprecation {deprecated_name!r}")
+    else:
+        parts.append(f"{access_type} deprecated {kind} {deprecated_name!r}")
+
+    parts.extend(
+        (
+            f"Deprecated in litestar {version}",
+            f"This {kind} will be removed in {removal_in or 'the next major version'}",
+        ),
+    )
+    if alternative:
+        parts.append(f"Use {alternative!r} instead")
+
+    if info:
+        parts.append(info)
+
+    text = ". ".join(parts)
+    warning_class = PendingDeprecationWarning if pending else DeprecationWarning
+
+    warn(text, warning_class, stacklevel=2)
+
+
+def deprecated(
+    version: str,
+    *,
+    removal_in: str | None = None,
+    alternative: str | None = None,
+    info: str | None = None,
+    pending: bool = False,
+    kind: Literal["function", "method", "classmethod", "property"] | None = None,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Create a decorator wrapping a function, method or property with a warning call about a (pending) deprecation.
+
+    Args:
+        version: Litestar version where the deprecation will occur
+        removal_in: Litestar version where the deprecated function will be removed
+        alternative: Name of a function that should be used instead
+        info: Additional information
+        pending: Use ``PendingDeprecationWarning`` instead of ``DeprecationWarning``
+        kind: Type of the deprecated callable. If ``None``, will use ``inspect`` to figure
+            out if it's a function or method
+
+    Returns:
+        A decorator wrapping the function call with a warning
+    """
+
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+        @wraps(func)
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
+            warn_deprecation(
+                version=version,
+                deprecated_name=func.__name__,
+                info=info,
+                alternative=alternative,
+                pending=pending,
+                removal_in=removal_in,
+                kind=kind or ("method" if inspect.ismethod(func) else "function"),
+            )
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1522,3 +1522,10 @@ async def test_service_upsert_many_method(
     assert upsert_update_objs[1].name in ("Agatha C.", "Inserted Author", "Custom Author")
     assert upsert_update_objs[2].id is not None
     assert upsert_update_objs[2].name in ("Agatha C.", "Inserted Author", "Custom Author")
+
+
+async def test_repo_get_or_create_deprecation(author_repo: AuthorRepository, first_author_id: Any) -> None:
+    with pytest.deprecated_call():
+        existing_obj, existing_created = await maybe_async(author_repo.get_or_create(name="Agatha Christie"))
+        assert existing_obj.id == first_author_id
+        assert existing_created is False


### PR DESCRIPTION
This PR adds a deprecation warning for the `get_or_create` function in the repository.

`get_or_create` was not a correct representation of what the function did.  `get_or_upsert` is the udpated name.