### PR TITLE
feat: verify the service has an identity before updating.

### DIFF
--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Generic, Iterable, cast
 
 from sqlalchemy.orm import InstrumentedAttribute
 
+from advanced_alchemy.exceptions import RepositoryError
 from advanced_alchemy.repository._util import model_from_dict
 from advanced_alchemy.repository.typing import ModelT
 
@@ -316,6 +317,11 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         data = await self.to_model(data, "update")
         if isinstance(id_attribute, InstrumentedAttribute):
             id_attribute = cast("str", id_attribute.description)
+        if item_id is None and self.repository.get_id_attribute_value(item=data, id_attribute=id_attribute) is None:
+            msg = f"Could not identify ID attribute value.  One of the following is required: ``item_id`` or ``data.{id_attribute or self.repository.id_attribute}``"
+            raise RepositoryError(
+                msg,
+            )
         if item_id is not None:
             data = self.repository.set_id_attribute_value(item_id=item_id, item=data, id_attribute=id_attribute)
         return await self.repository.update(

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -322,9 +322,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 "Could not identify ID attribute value.  One of the following is required: "
                 f"``item_id`` or ``data.{id_attribute or self.repository.id_attribute}``"
             )
-            raise RepositoryError(
-                msg,
-            )
+            raise RepositoryError(msg)
         if item_id is not None:
             data = self.repository.set_id_attribute_value(item_id=item_id, item=data, id_attribute=id_attribute)
         return await self.repository.update(

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -318,7 +318,10 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         if isinstance(id_attribute, InstrumentedAttribute):
             id_attribute = cast("str", id_attribute.description)
         if item_id is None and self.repository.get_id_attribute_value(item=data, id_attribute=id_attribute) is None:
-            msg = f"Could not identify ID attribute value.  One of the following is required: ``item_id`` or ``data.{id_attribute or self.repository.id_attribute}``"
+            msg = (
+                "Could not identify ID attribute value.  One of the following is required: "
+                f"``item_id`` or ``data.{id_attribute or self.repository.id_attribute}``"
+            )
             raise RepositoryError(
                 msg,
             )

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -319,7 +319,10 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         if isinstance(id_attribute, InstrumentedAttribute):
             id_attribute = cast("str", id_attribute.description)
         if item_id is None and self.repository.get_id_attribute_value(item=data, id_attribute=id_attribute) is None:
-            msg = f"Could not identify ID attribute value.  One of the following is required: ``item_id`` or ``data.{id_attribute or self.repository.id_attribute}``"
+            msg = (
+                "Could not identify ID attribute value.  One of the following is required: "
+                f"``item_id`` or ``data.{id_attribute or self.repository.id_attribute}``"
+            )
             raise RepositoryError(
                 msg,
             )

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Generic, Iterable, cast
 
 from sqlalchemy.orm import InstrumentedAttribute, Session
 
+from advanced_alchemy.exceptions import RepositoryError
 from advanced_alchemy.repository._util import model_from_dict
 from advanced_alchemy.repository.typing import ModelT
 
@@ -317,6 +318,11 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         data = self.to_model(data, "update")
         if isinstance(id_attribute, InstrumentedAttribute):
             id_attribute = cast("str", id_attribute.description)
+        if item_id is None and self.repository.get_id_attribute_value(item=data, id_attribute=id_attribute) is None:
+            msg = f"Could not identify ID attribute value.  One of the following is required: ``item_id`` or ``data.{id_attribute or self.repository.id_attribute}``"
+            raise RepositoryError(
+                msg,
+            )
         if item_id is not None:
             data = self.repository.set_id_attribute_value(item_id=item_id, item=data, id_attribute=id_attribute)
         return self.repository.update(

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -323,9 +323,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 "Could not identify ID attribute value.  One of the following is required: "
                 f"``item_id`` or ``data.{id_attribute or self.repository.id_attribute}``"
             )
-            raise RepositoryError(
-                msg,
-            )
+            raise RepositoryError(msg)
         if item_id is not None:
             data = self.repository.set_id_attribute_value(item_id=item_id, item=data, id_attribute=id_attribute)
         return self.repository.update(

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1550,3 +1550,8 @@ async def test_repo_get_or_create_deprecation(author_repo: AuthorRepository, fir
         existing_obj, existing_created = await maybe_async(author_repo.get_or_create(name="Agatha Christie"))
         assert existing_obj.id == first_author_id
         assert existing_created is False
+
+
+async def test_service_update_no_pk(author_service: AuthorService, first_author_id: Any) -> None:
+    with pytest.raises(RepositoryError):
+        _existing_obj = await maybe_async(author_service.update(data={"name": "Agatha Christie"}))

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -1552,6 +1552,6 @@ async def test_repo_get_or_create_deprecation(author_repo: AuthorRepository, fir
         assert existing_created is False
 
 
-async def test_service_update_no_pk(author_service: AuthorService, first_author_id: Any) -> None:
+async def test_service_update_no_pk(author_service: AuthorService) -> None:
     with pytest.raises(RepositoryError):
         _existing_obj = await maybe_async(author_service.update(data={"name": "Agatha Christie"}))


### PR DESCRIPTION
This PR raises a repository error when you call the service `update` method without an `item_id` and without a value for the ID attribute.

This ensures you are operating with data that can actually be updated.