### PR TITLE
feat: add `get_and_update` to the repository and services

### DIFF
--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -485,7 +485,8 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         """
         return await self.get_or_upsert(
             match_fields=match_fields,
-            upsert=upsert,
+            update=upsert,
+            create=upsert,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
             auto_commit=auto_commit,
@@ -497,7 +498,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
     async def get_or_upsert(
         self,
         match_fields: list[str] | str | None = None,
-        upsert: bool = True,
+        update: bool = True,
         create: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
@@ -511,7 +512,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.
-            upsert: When using match_fields and actual model values differ from
+            update: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
             create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
@@ -548,7 +549,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             self.check_not_found(existing)
         if not existing:
             return await self.add(self.model_type(**kwargs)), True  # pyright: ignore[reportGeneralTypeIssues]
-        if upsert:
+        if update:
             for field_name, new_field_value in kwargs.items():
                 field = getattr(existing, field_name, None)
                 if field and field != new_field_value:

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -485,8 +485,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         """
         return await self.get_or_upsert(
             match_fields=match_fields,
-            update=upsert,
-            create=upsert,
+            upsert=upsert,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
             auto_commit=auto_commit,

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -498,8 +498,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
     async def get_or_upsert(
         self,
         match_fields: list[str] | str | None = None,
-        update: bool = True,
-        create: bool = True,
+        upsert: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
         auto_commit: bool | None = None,
@@ -512,9 +511,8 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.
-            update: When using match_fields and actual model values differ from
-                `kwargs`, perform an update operation on the model.
-            create: Should a model be created.  If no model is found, an exception is raised.
+            upsert: When using match_fields and actual model values differ from
+                `kwargs`, automatically perform an update operation on the model.
             attribute_names: an iterable of attribute names to pass into the ``update``
                 method.
             with_for_update: indicating FOR UPDATE should be used, or may be a
@@ -545,11 +543,17 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         else:
             match_filter = kwargs
         existing = await self.get_one_or_none(**match_filter)
-        if not create:
-            self.check_not_found(existing)
         if not existing:
-            return await self.add(self.model_type(**kwargs)), True  # pyright: ignore[reportGeneralTypeIssues]
-        if update:
+            return (
+                await self.add(
+                    self.model_type(**kwargs),
+                    auto_commit=auto_commit,
+                    auto_refresh=auto_refresh,
+                    auto_expunge=auto_expunge,
+                ),
+                True,
+            )
+        if upsert:
             for field_name, new_field_value in kwargs.items():
                 field = getattr(existing, field_name, None)
                 if field and field != new_field_value:
@@ -564,6 +568,74 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             )
             self._expunge(existing, auto_expunge=auto_expunge)
         return existing, False
+
+    async def get_and_update(
+        self,
+        match_fields: list[str] | str | None = None,
+        attribute_names: Iterable[str] | None = None,
+        with_for_update: bool | None = None,
+        auto_commit: bool | None = None,
+        auto_expunge: bool | None = None,
+        auto_refresh: bool | None = None,
+        **kwargs: Any,
+    ) -> tuple[ModelT, bool]:
+        """Get instance identified by ``kwargs`` and update the model if the arguments are different.
+
+
+
+        Args:
+            match_fields: a list of keys to use to match the existing model.  When
+                empty, all fields are matched.
+            attribute_names: an iterable of attribute names to pass into the ``update``
+                method.
+            with_for_update: indicating FOR UPDATE should be used, or may be a
+                dictionary containing flags to indicate a more specific set of
+                FOR UPDATE flags for the SELECT
+            auto_expunge: Remove object from session before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_expunge <SQLAlchemyAsyncRepository>`.
+            auto_refresh: Refresh object from session before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_refresh <SQLAlchemyAsyncRepository>`
+            auto_commit: Commit objects before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
+            **kwargs: Identifier of the instance to be retrieved.
+
+        Returns:
+            a tuple that includes the instance and whether it needed to be updated.
+            When using match_fields and actual model values differ from ``kwargs``, the
+            model value will be updated.
+
+
+        Raises:
+            NotFoundError: If no instance found identified by `item_id`.
+        """
+        match_fields = match_fields or self.match_fields
+        if isinstance(match_fields, str):
+            match_fields = [match_fields]
+        if match_fields:
+            match_filter = {
+                field_name: kwargs.get(field_name, None)
+                for field_name in match_fields
+                if kwargs.get(field_name, None) is not None
+            }
+        else:
+            match_filter = kwargs
+        existing = await self.get_one(**match_filter)
+        updated = False
+        for field_name, new_field_value in kwargs.items():
+            field = getattr(existing, field_name, None)
+            if field and field != new_field_value:
+                updated = True
+                setattr(existing, field_name, new_field_value)
+        existing = await self._attach_to_session(existing, strategy="merge")
+        await self._flush_or_commit(auto_commit=auto_commit)
+        await self._refresh(
+            existing,
+            attribute_names=attribute_names,
+            with_for_update=with_for_update,
+            auto_refresh=auto_refresh,
+        )
+        self._expunge(existing, auto_expunge=auto_expunge)
+        return existing, updated
 
     async def count(
         self,

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -580,8 +580,6 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
     ) -> tuple[ModelT, bool]:
         """Get instance identified by ``kwargs`` and update the model if the arguments are different.
 
-
-
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -899,7 +899,6 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         auto_expunge: bool | None = None,
         auto_commit: bool | None = None,
         no_merge: bool = False,
-        match_fields: list[str] | str | None = None,
     ) -> list[ModelT]:
         """Update or create instance.
 
@@ -916,8 +915,6 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             no_merge: Skip the usage of optimized Merge statements
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
-            match_fields: a list of keys to use to match the existing model.  When
-                empty, all fields are matched.
 
         Returns:
             The updated or created instance.

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -498,6 +498,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         self,
         match_fields: list[str] | str | None = None,
         upsert: bool = True,
+        create: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
         auto_commit: bool | None = None,
@@ -512,6 +513,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
                 empty, all fields are matched.
             upsert: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
+            create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
                 method.
             with_for_update: indicating FOR UPDATE should be used, or may be a
@@ -542,6 +544,8 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         else:
             match_filter = kwargs
         existing = await self.get_one_or_none(**match_filter)
+        if not create:
+            self.check_not_found(existing)
         if not existing:
             return await self.add(self.model_type(**kwargs)), True  # pyright: ignore[reportGeneralTypeIssues]
         if upsert:
@@ -895,6 +899,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         auto_expunge: bool | None = None,
         auto_commit: bool | None = None,
         no_merge: bool = False,
+        match_fields: list[str] | str | None = None,
     ) -> list[ModelT]:
         """Update or create instance.
 
@@ -911,6 +916,8 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             no_merge: Skip the usage of optimized Merge statements
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
+            match_fields: a list of keys to use to match the existing model.  When
+                empty, all fields are matched.
 
         Returns:
             The updated or created instance.

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -486,8 +486,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         """
         return self.get_or_upsert(
             match_fields=match_fields,
-            update=upsert,
-            create=upsert,
+            upsert=upsert,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
             auto_commit=auto_commit,

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -581,8 +581,6 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
     ) -> tuple[ModelT, bool]:
         """Get instance identified by ``kwargs`` and update the model if the arguments are different.
 
-
-
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -900,7 +900,6 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         auto_expunge: bool | None = None,
         auto_commit: bool | None = None,
         no_merge: bool = False,
-        match_fields: list[str] | str | None = None,
     ) -> list[ModelT]:
         """Update or create instance.
 
@@ -917,8 +916,6 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
             no_merge: Skip the usage of optimized Merge statements
                 :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
-            match_fields: a list of keys to use to match the existing model.  When
-                empty, all fields are matched.
 
         Returns:
             The updated or created instance.

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -486,7 +486,8 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         """
         return self.get_or_upsert(
             match_fields=match_fields,
-            upsert=upsert,
+            update=upsert,
+            create=upsert,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
             auto_commit=auto_commit,
@@ -498,7 +499,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
     def get_or_upsert(
         self,
         match_fields: list[str] | str | None = None,
-        upsert: bool = True,
+        update: bool = True,
         create: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
@@ -512,7 +513,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.
-            upsert: When using match_fields and actual model values differ from
+            update: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
             create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
@@ -549,7 +550,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             self.check_not_found(existing)
         if not existing:
             return self.add(self.model_type(**kwargs)), True  # pyright: ignore[reportGeneralTypeIssues]
-        if upsert:
+        if update:
             for field_name, new_field_value in kwargs.items():
                 field = getattr(existing, field_name, None)
                 if field and field != new_field_value:

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -499,8 +499,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
     def get_or_upsert(
         self,
         match_fields: list[str] | str | None = None,
-        update: bool = True,
-        create: bool = True,
+        upsert: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
         auto_commit: bool | None = None,
@@ -513,9 +512,8 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.
-            update: When using match_fields and actual model values differ from
-                `kwargs`, perform an update operation on the model.
-            create: Should a model be created.  If no model is found, an exception is raised.
+            upsert: When using match_fields and actual model values differ from
+                `kwargs`, automatically perform an update operation on the model.
             attribute_names: an iterable of attribute names to pass into the ``update``
                 method.
             with_for_update: indicating FOR UPDATE should be used, or may be a
@@ -546,11 +544,17 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         else:
             match_filter = kwargs
         existing = self.get_one_or_none(**match_filter)
-        if not create:
-            self.check_not_found(existing)
         if not existing:
-            return self.add(self.model_type(**kwargs)), True  # pyright: ignore[reportGeneralTypeIssues]
-        if update:
+            return (
+                self.add(
+                    self.model_type(**kwargs),
+                    auto_commit=auto_commit,
+                    auto_refresh=auto_refresh,
+                    auto_expunge=auto_expunge,
+                ),
+                True,
+            )
+        if upsert:
             for field_name, new_field_value in kwargs.items():
                 field = getattr(existing, field_name, None)
                 if field and field != new_field_value:
@@ -565,6 +569,74 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             )
             self._expunge(existing, auto_expunge=auto_expunge)
         return existing, False
+
+    def get_and_update(
+        self,
+        match_fields: list[str] | str | None = None,
+        attribute_names: Iterable[str] | None = None,
+        with_for_update: bool | None = None,
+        auto_commit: bool | None = None,
+        auto_expunge: bool | None = None,
+        auto_refresh: bool | None = None,
+        **kwargs: Any,
+    ) -> tuple[ModelT, bool]:
+        """Get instance identified by ``kwargs`` and update the model if the arguments are different.
+
+
+
+        Args:
+            match_fields: a list of keys to use to match the existing model.  When
+                empty, all fields are matched.
+            attribute_names: an iterable of attribute names to pass into the ``update``
+                method.
+            with_for_update: indicating FOR UPDATE should be used, or may be a
+                dictionary containing flags to indicate a more specific set of
+                FOR UPDATE flags for the SELECT
+            auto_expunge: Remove object from session before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_expunge <SQLAlchemyAsyncRepository>`.
+            auto_refresh: Refresh object from session before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_refresh <SQLAlchemyAsyncRepository>`
+            auto_commit: Commit objects before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
+            **kwargs: Identifier of the instance to be retrieved.
+
+        Returns:
+            a tuple that includes the instance and whether it needed to be updated.
+            When using match_fields and actual model values differ from ``kwargs``, the
+            model value will be updated.
+
+
+        Raises:
+            NotFoundError: If no instance found identified by `item_id`.
+        """
+        match_fields = match_fields or self.match_fields
+        if isinstance(match_fields, str):
+            match_fields = [match_fields]
+        if match_fields:
+            match_filter = {
+                field_name: kwargs.get(field_name, None)
+                for field_name in match_fields
+                if kwargs.get(field_name, None) is not None
+            }
+        else:
+            match_filter = kwargs
+        existing = self.get_one(**match_filter)
+        updated = False
+        for field_name, new_field_value in kwargs.items():
+            field = getattr(existing, field_name, None)
+            if field and field != new_field_value:
+                updated = True
+                setattr(existing, field_name, new_field_value)
+        existing = self._attach_to_session(existing, strategy="merge")
+        self._flush_or_commit(auto_commit=auto_commit)
+        self._refresh(
+            existing,
+            attribute_names=attribute_names,
+            with_for_update=with_for_update,
+            auto_refresh=auto_refresh,
+        )
+        self._expunge(existing, auto_expunge=auto_expunge)
+        return existing, updated
 
     def count(
         self,

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -434,7 +434,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
     async def get_or_upsert(
         self,
         match_fields: list[str] | None = None,
-        upsert: bool = True,
+        update: bool = True,
         create: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
@@ -448,7 +448,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.
-            upsert: When using match_fields and actual model values differ from
+            update: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
             create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
@@ -471,7 +471,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         validated_model = await self.to_model(kwargs, "create")
         return await self.repository.get_or_upsert(
             match_fields=match_fields,
-            upsert=upsert,
+            update=update,
             create=create,
             attribute_names=attribute_names,
             with_for_update=with_for_update,

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -449,7 +449,6 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 empty, all fields are matched.
             upsert: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
-            create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
                 method.
             with_for_update: indicating FOR UPDATE should be used, or may be a

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -435,6 +435,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         self,
         match_fields: list[str] | None = None,
         upsert: bool = True,
+        create: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
         auto_commit: bool | None = None,
@@ -449,6 +450,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
                 empty, all fields are matched.
             upsert: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
+            create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
                 method.
             with_for_update: indicating FOR UPDATE should be used, or may be a
@@ -470,6 +472,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         return await self.repository.get_or_upsert(
             match_fields=match_fields,
             upsert=upsert,
+            create=create,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
             auto_commit=auto_commit,

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -433,9 +433,8 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
 
     async def get_or_upsert(
         self,
-        match_fields: list[str] | None = None,
-        update: bool = True,
-        create: bool = True,
+        match_fields: list[str] | str | None = None,
+        upsert: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
         auto_commit: bool | None = None,
@@ -448,7 +447,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.
-            update: When using match_fields and actual model values differ from
+            upsert: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
             create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
@@ -471,8 +470,50 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         validated_model = await self.to_model(kwargs, "create")
         return await self.repository.get_or_upsert(
             match_fields=match_fields,
-            update=update,
-            create=create,
+            upsert=upsert,
+            attribute_names=attribute_names,
+            with_for_update=with_for_update,
+            auto_commit=auto_commit,
+            auto_expunge=auto_expunge,
+            auto_refresh=auto_refresh,
+            **validated_model.to_dict(),
+        )
+
+    async def get_and_update(
+        self,
+        match_fields: list[str] | str | None = None,
+        attribute_names: Iterable[str] | None = None,
+        with_for_update: bool | None = None,
+        auto_commit: bool | None = None,
+        auto_expunge: bool | None = None,
+        auto_refresh: bool | None = None,
+        **kwargs: Any,
+    ) -> tuple[ModelT, bool]:
+        """Wrap repository instance creation.
+
+        Args:
+            match_fields: a list of keys to use to match the existing model.  When
+                empty, all fields are matched.
+            attribute_names: an iterable of attribute names to pass into the ``update``
+                method.
+            with_for_update: indicating FOR UPDATE should be used, or may be a
+                dictionary containing flags to indicate a more specific set of
+                FOR UPDATE flags for the SELECT
+            auto_expunge: Remove object from session before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_expunge <SQLAlchemyAsyncRepository>`.
+            auto_refresh: Refresh object from session before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_refresh <SQLAlchemyAsyncRepository>`
+            auto_commit: Commit objects before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
+            **kwargs: Identifier of the instance to be retrieved.
+
+        Returns:
+            Representation of updated instance.
+        """
+        match_fields = match_fields or self.match_fields
+        validated_model = await self.to_model(kwargs, "update")
+        return await self.repository.get_and_update(
+            match_fields=match_fields,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
             auto_commit=auto_commit,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -436,6 +436,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         self,
         match_fields: list[str] | None = None,
         upsert: bool = True,
+        create: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
         auto_commit: bool | None = None,
@@ -450,6 +451,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 empty, all fields are matched.
             upsert: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
+            create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
                 method.
             with_for_update: indicating FOR UPDATE should be used, or may be a
@@ -471,6 +473,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         return self.repository.get_or_upsert(
             match_fields=match_fields,
             upsert=upsert,
+            create=create,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
             auto_commit=auto_commit,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -435,7 +435,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
     def get_or_upsert(
         self,
         match_fields: list[str] | None = None,
-        upsert: bool = True,
+        update: bool = True,
         create: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
@@ -449,7 +449,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.
-            upsert: When using match_fields and actual model values differ from
+            update: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
             create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
@@ -472,7 +472,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         validated_model = self.to_model(kwargs, "create")
         return self.repository.get_or_upsert(
             match_fields=match_fields,
-            upsert=upsert,
+            update=update,
             create=create,
             attribute_names=attribute_names,
             with_for_update=with_for_update,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -434,9 +434,8 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
 
     def get_or_upsert(
         self,
-        match_fields: list[str] | None = None,
-        update: bool = True,
-        create: bool = True,
+        match_fields: list[str] | str | None = None,
+        upsert: bool = True,
         attribute_names: Iterable[str] | None = None,
         with_for_update: bool | None = None,
         auto_commit: bool | None = None,
@@ -449,7 +448,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         Args:
             match_fields: a list of keys to use to match the existing model.  When
                 empty, all fields are matched.
-            update: When using match_fields and actual model values differ from
+            upsert: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
             create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
@@ -472,8 +471,50 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         validated_model = self.to_model(kwargs, "create")
         return self.repository.get_or_upsert(
             match_fields=match_fields,
-            update=update,
-            create=create,
+            upsert=upsert,
+            attribute_names=attribute_names,
+            with_for_update=with_for_update,
+            auto_commit=auto_commit,
+            auto_expunge=auto_expunge,
+            auto_refresh=auto_refresh,
+            **validated_model.to_dict(),
+        )
+
+    def get_and_update(
+        self,
+        match_fields: list[str] | str | None = None,
+        attribute_names: Iterable[str] | None = None,
+        with_for_update: bool | None = None,
+        auto_commit: bool | None = None,
+        auto_expunge: bool | None = None,
+        auto_refresh: bool | None = None,
+        **kwargs: Any,
+    ) -> tuple[ModelT, bool]:
+        """Wrap repository instance creation.
+
+        Args:
+            match_fields: a list of keys to use to match the existing model.  When
+                empty, all fields are matched.
+            attribute_names: an iterable of attribute names to pass into the ``update``
+                method.
+            with_for_update: indicating FOR UPDATE should be used, or may be a
+                dictionary containing flags to indicate a more specific set of
+                FOR UPDATE flags for the SELECT
+            auto_expunge: Remove object from session before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_expunge <SQLAlchemyAsyncRepository>`.
+            auto_refresh: Refresh object from session before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_refresh <SQLAlchemyAsyncRepository>`
+            auto_commit: Commit objects before returning. Defaults to
+                :class:`SQLAlchemyAsyncRepository.auto_commit <SQLAlchemyAsyncRepository>`
+            **kwargs: Identifier of the instance to be retrieved.
+
+        Returns:
+            Representation of updated instance.
+        """
+        match_fields = match_fields or self.match_fields
+        validated_model = self.to_model(kwargs, "update")
+        return self.repository.get_and_update(
+            match_fields=match_fields,
             attribute_names=attribute_names,
             with_for_update=with_for_update,
             auto_commit=auto_commit,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -450,7 +450,6 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
                 empty, all fields are matched.
             upsert: When using match_fields and actual model values differ from
                 `kwargs`, perform an update operation on the model.
-            create: Should a model be created.  If no model is found, an exception is raised.
             attribute_names: an iterable of attribute names to pass into the ``update``
                 method.
             with_for_update: indicating FOR UPDATE should be used, or may be a

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -969,11 +969,23 @@ async def test_repo_get_or_upsert_match_filter_no_upsert(author_repo: AuthorRepo
     assert existing_created is False
 
 
-async def test_repo_get_or_upsert_match_filter_no_create(author_repo: AuthorRepository, first_author_id: Any) -> None:
+async def test_repo_get_and_update(author_repo: AuthorRepository, first_author_id: Any) -> None:
+    existing_obj, existing_updated = await maybe_async(
+        author_repo.get_and_update(name="Agatha Christie"),
+    )
+    assert existing_obj.id == first_author_id
+    assert existing_updated is False
+
+
+async def test_repo_get_and_upsert_match_filter(author_repo: AuthorRepository, first_author_id: Any) -> None:
     now = datetime.now()
     with pytest.raises(NotFoundError):
         _ = await maybe_async(
-            author_repo.get_or_upsert(match_fields="name", create=False, name="Agatha Christie123", dob=now.date()),
+            author_repo.get_and_update(match_fields="name", name="Agatha Christie123", dob=now.date()),
+        )
+    with pytest.raises(NotFoundError):
+        _ = await maybe_async(
+            author_repo.get_and_update(name="Agatha Christie123"),
         )
 
 
@@ -1509,6 +1521,16 @@ async def test_service_get_or_upsert_method(author_service: AuthorService, first
     assert new_obj.id is not None
     assert new_obj.name == "New Author"
     assert new_created
+
+
+async def test_service_get_and_update_method(author_service: AuthorService, first_author_id: Any) -> None:
+    existing_obj, existing_created = await maybe_async(
+        author_service.get_and_update(name="Agatha Christie", match_fields="name"),
+    )
+    assert existing_obj.id == first_author_id
+    assert existing_created is False
+    with pytest.raises(NotFoundError):
+        _ = await maybe_async(author_service.get_and_update(name="New Author"))
 
 
 async def test_service_upsert_method(

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -962,7 +962,7 @@ async def test_repo_get_or_upsert_match_filter(author_repo: AuthorRepository, fi
 async def test_repo_get_or_upsert_match_filter_no_upsert(author_repo: AuthorRepository, first_author_id: Any) -> None:
     now = datetime.now()
     existing_obj, existing_created = await maybe_async(
-        author_repo.get_or_upsert(match_fields="name", upsert=False, name="Agatha Christie", dob=now.date()),
+        author_repo.get_or_upsert(match_fields="name", update=False, name="Agatha Christie", dob=now.date()),
     )
     assert existing_obj.id == first_author_id
     assert existing_obj.dob != now.date()

--- a/tests/integration/test_repository.py
+++ b/tests/integration/test_repository.py
@@ -962,7 +962,7 @@ async def test_repo_get_or_upsert_match_filter(author_repo: AuthorRepository, fi
 async def test_repo_get_or_upsert_match_filter_no_upsert(author_repo: AuthorRepository, first_author_id: Any) -> None:
     now = datetime.now()
     existing_obj, existing_created = await maybe_async(
-        author_repo.get_or_upsert(match_fields="name", update=False, name="Agatha Christie", dob=now.date()),
+        author_repo.get_or_upsert(match_fields="name", upsert=False, name="Agatha Christie", dob=now.date()),
     )
     assert existing_obj.id == first_author_id
     assert existing_obj.dob != now.date()

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -415,7 +415,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_existing_no_upsert(
     mock_repo_execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=mock_instance))
 
     instance, created = await maybe_async(
-        mock_repo.get_or_upsert(id="instance-id", update=False, an_extra_attribute="yep"),
+        mock_repo.get_or_upsert(id="instance-id", upsert=False, an_extra_attribute="yep"),
     )
 
     assert instance is mock_instance

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -373,7 +373,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_existing(
     mock_repo_execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=mock_instance))
     mock_repo_attach_to_session.return_value = mock_instance
 
-    instance, created = await maybe_async(mock_repo.get_or_upsert(id="instance-id", update=False))
+    instance, created = await maybe_async(mock_repo.get_or_upsert(id="instance-id", upsert=False))
 
     assert instance is mock_instance
     assert created is False
@@ -394,7 +394,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_existing_upsert(
     mock_repo_attach_to_session.return_value = mock_instance
 
     instance, created = await maybe_async(
-        mock_repo.get_or_upsert(id="instance-id", update=True, an_extra_attribute="yep"),
+        mock_repo.get_or_upsert(id="instance-id", upsert=True, an_extra_attribute="yep"),
     )
 
     assert instance is mock_instance

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -373,7 +373,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_existing(
     mock_repo_execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=mock_instance))
     mock_repo_attach_to_session.return_value = mock_instance
 
-    instance, created = await maybe_async(mock_repo.get_or_upsert(id="instance-id", upsert=False))
+    instance, created = await maybe_async(mock_repo.get_or_upsert(id="instance-id", update=False))
 
     assert instance is mock_instance
     assert created is False
@@ -394,7 +394,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_existing_upsert(
     mock_repo_attach_to_session.return_value = mock_instance
 
     instance, created = await maybe_async(
-        mock_repo.get_or_upsert(id="instance-id", upsert=True, an_extra_attribute="yep"),
+        mock_repo.get_or_upsert(id="instance-id", update=True, an_extra_attribute="yep"),
     )
 
     assert instance is mock_instance
@@ -415,7 +415,7 @@ async def test_sqlalchemy_repo_get_or_upsert_member_existing_no_upsert(
     mock_repo_execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=mock_instance))
 
     instance, created = await maybe_async(
-        mock_repo.get_or_upsert(id="instance-id", upsert=False, an_extra_attribute="yep"),
+        mock_repo.get_or_upsert(id="instance-id", update=False, an_extra_attribute="yep"),
     )
 
     assert instance is mock_instance


### PR DESCRIPTION
Adds `get_and_update` functions to the repository.  If the record is not found, and exception is raised. 

-------

Now that we've renamed the method to `get_or_upsert`, there have been a few cases where I have needed to temporarily disable one of the operations on the endpoint.  @JacobCoffee asked for something similar recently as well.

Rather than add a `get_and_update` method that disables the "insert" operation of the `get_or_upsert`, I am proposing we have an additional parameter (and rename an existing one) to optionally disable the create and update operations on the function.

This PR:
- renames the `upsert` parameter to `update`.
- adds a `create` parameter

Both of these default to `True` to ensure current functionality stays consistent.