### PR TITLE
fix: reference column names from `Mapper` object in `model_from_dict`

### DIFF
--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import (
     mapped_column,
     orm_insert_sentinel,
     registry,
+    Mapper
 )
 
 from advanced_alchemy.types import GUID, BigIntIdentity, DateTimeUTC, JsonB
@@ -78,8 +79,9 @@ class ModelProtocol(Protocol):
     """The base SQLAlchemy model protocol."""
 
     __table__: FromClause
+    __mapper__: Mapper
     __name__: ClassVar[str]
-
+    
     def to_dict(self, exclude: set[str] | None = None) -> dict[str, Any]:
         """Convert model to dictionary.
 

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -13,12 +13,12 @@ from sqlalchemy.event import listens_for
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
+    Mapper,
     Session,
     declared_attr,
     mapped_column,
     orm_insert_sentinel,
     registry,
-    Mapper
 )
 
 from advanced_alchemy.types import GUID, BigIntIdentity, DateTimeUTC, JsonB
@@ -81,7 +81,7 @@ class ModelProtocol(Protocol):
     __table__: FromClause
     __mapper__: Mapper
     __name__: ClassVar[str]
-    
+
     def to_dict(self, exclude: set[str] | None = None) -> dict[str, Any]:
         """Convert model to dictionary.
 
@@ -137,6 +137,7 @@ class CommonTableAttributes:
 
     __name__: ClassVar[str]
     __table__: FromClause
+    __mapper__: Mapper
 
     # noinspection PyMethodParameters
     @declared_attr.directive

--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -47,9 +47,8 @@ def get_instrumented_attr(model: type[ModelProtocol], key: str | InstrumentedAtt
 def model_from_dict(model: ModelT, **kwargs: Any) -> ModelT:
     """Return ORM Object from Dictionary."""
     data = {}
-    for column_name in model.__mapper__.columns.keys():
+    for column_name in model.__mapper__.columns.keys():  # noqa: SIM118
         column_val = kwargs.get(column_name, None)
         if column_val is not None:
             data[column_name] = column_val
     return model(**data)  # type: ignore  # noqa: PGH003
-

--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -47,8 +47,9 @@ def get_instrumented_attr(model: type[ModelProtocol], key: str | InstrumentedAtt
 def model_from_dict(model: ModelT, **kwargs: Any) -> ModelT:
     """Return ORM Object from Dictionary."""
     data = {}
-    for column in model.__table__.columns:
-        column_val = kwargs.get(column.name, None)
+    for column_name in model.__mapper__.columns.keys():
+        column_val = kwargs.get(column_name, None)
         if column_val is not None:
-            data[column.name] = column_val
+            data[column_name] = column_val
     return model(**data)  # type: ignore  # noqa: PGH003
+


### PR DESCRIPTION
### Pull Request Checklist

- [ ] New code has 100% test coverage
- [-] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [-] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
Positional name's can't find by column model.__table__.columns.

### Close Issue(s)
 "Fixes #74"
