### PR TITLE
fix: change `upsert_many` behavior

### DIFF
--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -526,8 +526,9 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             When using match_fields and actual model values differ from ``kwargs``, the
             model value will be updated.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields, id_attribute=None)
-        if match_fields:
+        if match_fields := self._get_match_fields(
+            match_fields=match_fields, id_attribute=None
+        ):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
                 for field_name in match_fields
@@ -599,8 +600,9 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields, id_attribute=None)
-        if match_fields:
+        if match_fields := self._get_match_fields(
+            match_fields=match_fields, id_attribute=None
+        ):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
                 for field_name in match_fields
@@ -928,8 +930,9 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields, id_attribute=None)
-        if match_fields:
+        if match_fields := self._get_match_fields(
+            match_fields=match_fields, id_attribute=None
+        ):
             match_filter = {
                 field_name: getattr(data, field_name, None)
                 for field_name in match_fields

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1023,7 +1023,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             for field_name in match_fields:
                 field = get_instrumented_attr(self.model_type, field_name)
                 matched_values = [
-                    getattr(datum, field_name) for datum in data if getattr(datum, field_name) is not None
+                    field_data for datum in data if (field_data := getattr(datum, field_name)) is not None
                 ]
                 if self._prefer_any:
                     match_filter.append(any_(matched_values) == field)  # type: ignore[arg-type]

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -527,7 +527,8 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             model value will be updated.
         """
         if match_fields := self._get_match_fields(
-            match_fields=match_fields, id_attribute=None
+            match_fields=match_fields,
+            id_attribute=None,
         ):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
@@ -601,7 +602,8 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             NotFoundError: If no instance found identified by `item_id`.
         """
         if match_fields := self._get_match_fields(
-            match_fields=match_fields, id_attribute=None
+            match_fields=match_fields,
+            id_attribute=None,
         ):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
@@ -931,7 +933,8 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             NotFoundError: If no instance found with same identifier as `data`.
         """
         if match_fields := self._get_match_fields(
-            match_fields=match_fields, id_attribute=None
+            match_fields=match_fields,
+            id_attribute=None,
         ):
             match_filter = {
                 field_name: getattr(data, field_name, None)

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1016,26 +1016,40 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         match_fields = match_fields or self.match_fields
         if isinstance(match_fields, str):
             match_fields = [match_fields]
-        match_filter: list[FilterTypes | ColumnElement[bool]] = [
-            CollectionFilter(
-                field_name=self.id_attribute,
-                values=[getattr(datum, self.id_attribute) for datum in data if datum is not None] if data else None,
-            ),
-        ]
+        if match_fields is None:
+            match_fields = [self.id_attribute]
+        match_filter: list[FilterTypes | ColumnElement[bool]] = []
         if match_fields:
             for field_name in match_fields:
                 field = get_instrumented_attr(self.model_type, field_name)
-                matched_values = [getattr(datum, field_name) for datum in data if datum is not None]
+                matched_values = [
+                    getattr(datum, field_name) for datum in data if getattr(datum, field_name) is not None
+                ]
                 if self._prefer_any:
                     match_filter.append(any_(matched_values) == field)  # type: ignore[arg-type]
                 else:
                     match_filter.append(field.in_(matched_values))
 
         with wrap_sqlalchemy_exception():
-            existing_objs = await self.list(*match_filter, auto_expunge=False)
-            existing_ids = [getattr(datum, self.id_attribute) for datum in existing_objs if datum is not None]
+            existing_objs = await self.list(
+                *match_filter,
+                auto_expunge=False,
+            )
+            for field_name in match_fields:
+                field = get_instrumented_attr(self.model_type, field_name)
+                matched_values = [getattr(datum, field_name) for datum in existing_objs if datum is not None]
+                if self._prefer_any:
+                    match_filter.append(any_(matched_values) == field)  # type: ignore[arg-type]
+                else:
+                    match_filter.append(field.in_(matched_values))
+            existing_ids = [
+                getattr(datum, self.id_attribute)
+                for datum in existing_objs
+                if getattr(datum, self.id_attribute) is not None
+            ]
+            data = self._merge_on_match_fields(data, existing_objs, match_fields)
             for datum in data:
-                if getattr(datum, self.id_attribute) is not None in existing_ids:
+                if getattr(datum, self.id_attribute, None) in existing_ids:
                     data_to_update.append(datum)
                 else:
                     data_to_insert.append(datum)
@@ -1051,6 +1065,26 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             for instance in instances:
                 self._expunge(instance, auto_expunge=auto_expunge)
         return instances
+
+    def _merge_on_match_fields(
+        self,
+        data: list[ModelT],
+        existing_data: list[ModelT],
+        match_fields: list[str] | str | None = None,
+    ) -> list[ModelT]:
+        match_fields = match_fields or self.match_fields
+        if isinstance(match_fields, str):
+            match_fields = [match_fields]
+        if match_fields is None:
+            match_fields = [self.id_attribute]
+        for existing_datum in existing_data:
+            for row_id, datum in enumerate(data):
+                match = all(
+                    getattr(datum, field_name) == getattr(existing_datum, field_name) for field_name in match_fields
+                )
+                if match and getattr(existing_datum, self.id_attribute) is not None:
+                    setattr(data[row_id], self.id_attribute, getattr(existing_datum, self.id_attribute))
+        return data
 
     async def list(
         self,

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -1043,9 +1043,9 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
                 else:
                     match_filter.append(field.in_(matched_values))
             existing_ids = [
-                getattr(datum, self.id_attribute)
+                obj_id
                 for datum in existing_objs
-                if getattr(datum, self.id_attribute) is not None
+                if (obj_id := getattr(datum, self.id_attribute)) is not None
             ]
             data = self._merge_on_match_fields(data, existing_objs, match_fields)
             for datum in data:

--- a/advanced_alchemy/repository/_async.py
+++ b/advanced_alchemy/repository/_async.py
@@ -526,8 +526,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
             When using match_fields and actual model values differ from ``kwargs``, the
             model value will be updated.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields)
-        if match_fields:
+        if match_fields := self._get_match_fields(match_fields=match_fields):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
                 for field_name in match_fields
@@ -599,8 +598,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields)
-        if match_fields:
+        if match_fields := self._get_match_fields(match_fields=match_fields):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
                 for field_name in match_fields
@@ -928,8 +926,7 @@ class SQLAlchemyAsyncRepository(Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields)
-        if match_fields:
+        if match_fields := self._get_match_fields(match_fields=match_fields):
             match_filter = {
                 field_name: getattr(data, field_name, None)
                 for field_name in match_fields

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -527,8 +527,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             When using match_fields and actual model values differ from ``kwargs``, the
             model value will be updated.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields)
-        if match_fields:
+        if match_fields := self._get_match_fields(match_fields=match_fields):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
                 for field_name in match_fields
@@ -600,8 +599,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields)
-        if match_fields:
+        if match_fields := self._get_match_fields(match_fields=match_fields):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
                 for field_name in match_fields
@@ -929,8 +927,7 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields)
-        if match_fields:
+        if match_fields := self._get_match_fields(match_fields=match_fields):
             match_filter = {
                 field_name: getattr(data, field_name, None)
                 for field_name in match_fields

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -527,8 +527,9 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             When using match_fields and actual model values differ from ``kwargs``, the
             model value will be updated.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields, id_attribute=None)
-        if match_fields:
+        if match_fields := self._get_match_fields(
+            match_fields=match_fields, id_attribute=None
+        ):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
                 for field_name in match_fields
@@ -600,8 +601,9 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found identified by `item_id`.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields, id_attribute=None)
-        if match_fields:
+        if match_fields := self._get_match_fields(
+            match_fields=match_fields, id_attribute=None
+        ):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
                 for field_name in match_fields
@@ -929,8 +931,9 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
         Raises:
             NotFoundError: If no instance found with same identifier as `data`.
         """
-        match_fields = self._get_match_fields(match_fields=match_fields, id_attribute=None)
-        if match_fields:
+        if match_fields := self._get_match_fields(
+            match_fields=match_fields, id_attribute=None
+        ):
             match_filter = {
                 field_name: getattr(data, field_name, None)
                 for field_name in match_fields

--- a/advanced_alchemy/repository/_sync.py
+++ b/advanced_alchemy/repository/_sync.py
@@ -528,7 +528,8 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             model value will be updated.
         """
         if match_fields := self._get_match_fields(
-            match_fields=match_fields, id_attribute=None
+            match_fields=match_fields,
+            id_attribute=None,
         ):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
@@ -602,7 +603,8 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             NotFoundError: If no instance found identified by `item_id`.
         """
         if match_fields := self._get_match_fields(
-            match_fields=match_fields, id_attribute=None
+            match_fields=match_fields,
+            id_attribute=None,
         ):
             match_filter = {
                 field_name: kwargs.get(field_name, None)
@@ -932,7 +934,8 @@ class SQLAlchemySyncRepository(Generic[ModelT]):
             NotFoundError: If no instance found with same identifier as `data`.
         """
         if match_fields := self._get_match_fields(
-            match_fields=match_fields, id_attribute=None
+            match_fields=match_fields,
+            id_attribute=None,
         ):
             match_filter = {
                 field_name: getattr(data, field_name, None)


### PR DESCRIPTION
This PR changes the `upsert_many` logic.

Previously, it had no way of merging the identify of the existing objects back to the data being inserted.  This change will merge the identiy value on to the data to be udpated.