### PR TITLE
fix: adds the `python_type` property.  

### DIFF
--- a/advanced_alchemy/types.py
+++ b/advanced_alchemy/types.py
@@ -151,6 +151,10 @@ class DateTimeUTC(TypeDecorator):
     impl = DateTime(timezone=True)
     cache_ok = True
 
+    @property
+    def python_type(self) -> type[datetime.datetime]:
+        return datetime.datetime
+
     def process_bind_param(self, value: datetime.datetime | None, dialect: Dialect) -> datetime.datetime | None:
         if value is None:
             return value


### PR DESCRIPTION
This implements the `python_type` property for `DateTimeUTC`.

This is used by other libraries such as `polyfactory`.  It was previously raising a `NotImplementedError` instead of returning a `datetime` type.