### PR TITLE
fix: add `str` to `match_fields` type hint

### DIFF
--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -31,7 +31,7 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT]):
     """Service object that operates on a repository object."""
 
     repository_type: type[SQLAlchemyAsyncRepository[ModelT]]
-    match_fields: list[str] | None = None
+    match_fields: list[str] | str | None = None
 
     def __init__(
         self,

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -366,7 +366,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         auto_expunge: bool | None = None,
         auto_commit: bool | None = None,
         auto_refresh: bool | None = None,
-        match_fields: list[str] | None = None,
+        match_fields: list[str] | str | None = None,
     ) -> ModelT:
         """Wrap repository upsert operation.
 
@@ -411,7 +411,7 @@ class SQLAlchemyAsyncRepositoryService(SQLAlchemyAsyncRepositoryReadService[Mode
         auto_expunge: bool | None = None,
         auto_commit: bool | None = None,
         no_merge: bool = False,
-        match_fields: list[str] | None = None,
+        match_fields: list[str] | str | None = None,
     ) -> list[ModelT]:
         """Wrap repository upsert operation.
 

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -367,7 +367,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         auto_expunge: bool | None = None,
         auto_commit: bool | None = None,
         auto_refresh: bool | None = None,
-        match_fields: list[str] | None = None,
+        match_fields: list[str] | str | None = None,
     ) -> ModelT:
         """Wrap repository upsert operation.
 
@@ -412,7 +412,7 @@ class SQLAlchemySyncRepositoryService(SQLAlchemySyncRepositoryReadService[ModelT
         auto_expunge: bool | None = None,
         auto_commit: bool | None = None,
         no_merge: bool = False,
-        match_fields: list[str] | None = None,
+        match_fields: list[str] | str | None = None,
     ) -> list[ModelT]:
         """Wrap repository upsert operation.
 

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -32,7 +32,7 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT]):
     """Service object that operates on a repository object."""
 
     repository_type: type[SQLAlchemySyncRepository[ModelT]]
-    match_fields: list[str] | None = None
+    match_fields: list[str] | str | None = None
 
     def __init__(
         self,


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Jolt's Code of Conduct](https://github.com/jolt-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Jolt's contribution guidelines](https://github.com/jolt-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

-  The `str` type hint was missing from the service declaration.  This needs to be added to align with the repositoryl

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- 
