### PR TITLE
refactor: use internal utilities for scope state storage.

### DIFF
--- a/advanced_alchemy/extensions/litestar/_utils.py
+++ b/advanced_alchemy/extensions/litestar/_utils.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from litestar.types import Scope
+
+__all__ = (
+    "delete_aa_scope_state",
+    "get_aa_scope_state",
+    "set_aa_scope_state",
+)
+
+_SCOPE_NAMESPACE = "_aa_connection_state"
+
+
+def get_aa_scope_state(scope: Scope, key: str, default: Any = None, pop: bool = False) -> Any:
+    """Get an internal value from connection scope state.
+
+    Note:
+        If called with a default value, this method behaves like to `dict.set_default()`, both setting the key in the
+        namespace to the default value, and returning it.
+
+        If called without a default value, the method behaves like `dict.get()`, returning ``None`` if the key does not
+        exist.
+
+    Args:
+        scope: The connection scope.
+        key: Key to get from internal namespace in scope state.
+        default: Default value to return.
+        pop: Boolean flag dictating whether the value should be deleted from the state.
+
+    Returns:
+        Value mapped to ``key`` in internal connection scope namespace.
+    """
+    namespace = scope.setdefault(_SCOPE_NAMESPACE, {})  # type: ignore[misc]
+    return namespace.pop(key, default) if pop else namespace.get(key, default)
+
+
+def set_aa_scope_state(scope: Scope, key: str, value: Any) -> None:
+    """Set an internal value in connection scope state.
+
+    Args:
+        scope: The connection scope.
+        key: Key to set under internal namespace in scope state.
+        value: Value for key.
+    """
+    scope.setdefault(_SCOPE_NAMESPACE, {})[key] = value  # type: ignore[misc]
+
+
+def delete_aa_scope_state(scope: Scope, key: str) -> None:
+    """Delete an internal value from connection scope state.
+
+    Args:
+        scope: The connection scope.
+        key: Key to set under internal namespace in scope state.
+    """
+    del scope.setdefault(_SCOPE_NAMESPACE, {})[key]  # type: ignore[misc]

--- a/tests/unit/test_extensions/test_litestar/test_init_plugin/test_asyncio.py
+++ b/tests/unit/test_extensions/test_litestar/test_init_plugin/test_asyncio.py
@@ -8,10 +8,10 @@ from asgi_lifespan import LifespanManager
 from litestar import Litestar, get
 from litestar.testing import create_test_client
 from litestar.types.asgi_types import HTTPResponseStartEvent
-from litestar.utils import set_litestar_scope_state
 from pytest import MonkeyPatch
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from advanced_alchemy.extensions.litestar._utils import set_aa_scope_state
 from advanced_alchemy.extensions.litestar.plugins import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 from advanced_alchemy.extensions.litestar.plugins.init.config.asyncio import (
     autocommit_before_send_handler,
@@ -80,7 +80,7 @@ async def test_before_send_handler_success_response(create_scope: Callable[..., 
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=AsyncSession)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(200, 299),
@@ -99,7 +99,7 @@ async def test_before_send_handler_error_response(create_scope: Callable[..., Sc
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=AsyncSession)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(300, 599),
@@ -119,7 +119,7 @@ async def test_autocommit_handler_maker_redirect_response(create_scope: Callable
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=AsyncSession)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(300, 399),
@@ -139,7 +139,7 @@ async def test_autocommit_handler_maker_commit_statuses(create_scope: Callable[.
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=AsyncSession)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(302, 303),
@@ -159,7 +159,7 @@ async def test_autocommit_handler_maker_rollback_statuses(create_scope: Callable
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=AsyncSession)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(307, 308),

--- a/tests/unit/test_extensions/test_litestar/test_init_plugin/test_common.py
+++ b/tests/unit/test_extensions/test_litestar/test_init_plugin/test_common.py
@@ -4,11 +4,11 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-from litestar.constants import SCOPE_STATE_NAMESPACE
 from litestar.datastructures import State
 from sqlalchemy import create_engine
 
 from advanced_alchemy.exceptions import ImproperConfigurationError
+from advanced_alchemy.extensions.litestar._utils import _SCOPE_NAMESPACE
 from advanced_alchemy.extensions.litestar.plugins import SQLAlchemyAsyncConfig, SQLAlchemySyncConfig
 from advanced_alchemy.extensions.litestar.plugins.init.config.common import SESSION_SCOPE_KEY
 
@@ -119,15 +119,15 @@ def test_create_session_instance_if_session_not_in_scope_state(
 ) -> None:
     """Test provide_session if session not in scope state."""
     with patch(
-        "litestar.utils.get_litestar_scope_state",
-    ) as get_litestar_scope_state_mock:
-        get_litestar_scope_state_mock.return_value = None
+        "advanced_alchemy.extensions.litestar._utils.get_aa_scope_state",
+    ) as get_scope_state_mock:
+        get_scope_state_mock.return_value = None
         config = config_cls()
         state = State()
         state[config.session_maker_app_state_key] = MagicMock()
-        scope: Scope = {"state": {}}  # type:ignore[assignment]
+        scope: Scope = {}  # type:ignore[assignment]
         assert isinstance(config.provide_session(state, scope), MagicMock)
-        assert SESSION_SCOPE_KEY in scope["state"][SCOPE_STATE_NAMESPACE]
+        assert SESSION_SCOPE_KEY in scope[_SCOPE_NAMESPACE]  # type: ignore[literal-required]
 
 
 def test_app_state(config_cls: type[SQLAlchemySyncConfig], monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/test_extensions/test_litestar/test_init_plugin/test_sync.py
+++ b/tests/unit/test_extensions/test_litestar/test_init_plugin/test_sync.py
@@ -8,10 +8,10 @@ from asgi_lifespan import LifespanManager
 from litestar import Litestar, get
 from litestar.testing import create_test_client
 from litestar.types.asgi_types import HTTPResponseStartEvent
-from litestar.utils import set_litestar_scope_state
 from pytest import MonkeyPatch
 from sqlalchemy.orm import Session
 
+from advanced_alchemy.extensions.litestar._utils import set_aa_scope_state
 from advanced_alchemy.extensions.litestar.plugins import (
     SQLAlchemyInitPlugin,
     SQLAlchemySyncConfig,
@@ -81,7 +81,7 @@ def test_before_send_handler_success_response(create_scope: Callable[..., Scope]
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=Session)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(200, 299),
@@ -97,7 +97,7 @@ def test_before_send_handler_error_response(create_scope: Callable[..., Scope]) 
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=Session)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(300, 599),
@@ -117,7 +117,7 @@ def test_autocommit_handler_maker_redirect_response(create_scope: Callable[..., 
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=Session)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(300, 399),
@@ -137,7 +137,7 @@ def test_autocommit_handler_maker_commit_statuses(create_scope: Callable[..., Sc
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=Session)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(302, 303),
@@ -157,7 +157,7 @@ def test_autocommit_handler_maker_rollback_statuses(create_scope: Callable[..., 
     app = Litestar(route_handlers=[], plugins=[SQLAlchemyInitPlugin(config)])
     mock_session = MagicMock(spec=Session)
     http_scope = create_scope(app=app)
-    set_litestar_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
+    set_aa_scope_state(http_scope, SESSION_SCOPE_KEY, mock_session)
     http_response_start: HTTPResponseStartEvent = {
         "type": "http.response.start",
         "status": random.randint(307, 308),


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Jolt's Code of Conduct](https://github.com/jolt-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Jolt's contribution guidelines](https://github.com/jolt-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

Litestar has deprecated external use of their scope state namespace.

This PR implements scope state utilities that manage a namespace unique to advanced-alchemy.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

Closes #103
