### PR TITLE
fix: correct `count` and `list_and_count` signatures

### DIFF
--- a/advanced_alchemy/repository/memory/_async.py
+++ b/advanced_alchemy/repository/memory/_async.py
@@ -269,11 +269,19 @@ class SQLAlchemyAsyncMockRepository(Generic[ModelT]):
             match_fields = [match_fields]
         return match_fields
 
-    async def _list_and_count_basic(self, *filters: FilterTypes, **kwargs: Any) -> tuple[list[ModelT], int]:
+    async def _list_and_count_basic(
+        self,
+        *filters: FilterTypes | ColumnElement[bool],
+        **kwargs: Any,
+    ) -> tuple[list[ModelT], int]:
         result = await self.list(*filters, **kwargs)
         return result, len(result)
 
-    async def _list_and_count_window(self, *filters: FilterTypes, **kwargs: Any) -> tuple[list[ModelT], int]:
+    async def _list_and_count_window(
+        self,
+        *filters: FilterTypes | ColumnElement[bool],
+        **kwargs: Any,
+    ) -> tuple[list[ModelT], int]:
         return await self._list_and_count_basic(*filters, **kwargs)
 
     def _find_or_raise_not_found(self, id_: Any) -> ModelT:
@@ -414,7 +422,11 @@ class SQLAlchemyAsyncMockRepository(Generic[ModelT]):
     async def upsert_many(self, data: list[ModelT], **_: Any) -> list[ModelT]:
         return [await self.upsert(item) for item in data]
 
-    async def list_and_count(self, *filters: FilterTypes, **kwargs: Any) -> tuple[list[ModelT], int]:
+    async def list_and_count(
+        self,
+        *filters: FilterTypes | ColumnElement[bool],
+        **kwargs: Any,
+    ) -> tuple[list[ModelT], int]:
         return await self._list_and_count_basic(*filters, **kwargs)
 
     def filter_collection_by_kwargs(self, collection: CollectionT, /, **kwargs: Any) -> CollectionT:

--- a/advanced_alchemy/repository/memory/_async.py
+++ b/advanced_alchemy/repository/memory/_async.py
@@ -415,6 +415,7 @@ class SQLAlchemyAsyncMockRepository(Generic[ModelT]):
         return deleted
 
     async def upsert(self, data: ModelT, **_: Any) -> ModelT:
+        # sourcery skip: assign-if-exp, reintroduce-else
         if data in self.__collection__():
             return await self.update(data)
         return await self.add(data)

--- a/advanced_alchemy/repository/memory/_sync.py
+++ b/advanced_alchemy/repository/memory/_sync.py
@@ -418,9 +418,7 @@ class SQLAlchemySyncMockRepository(Generic[ModelT]):
         return deleted
 
     def upsert(self, data: ModelT, **_: Any) -> ModelT:
-        if data in self.__collection__():
-            return self.update(data)
-        return self.add(data)
+        return self.update(data) if data in self.__collection__() else self.add(data)
 
     def upsert_many(self, data: list[ModelT], **_: Any) -> list[ModelT]:
         return [self.upsert(item) for item in data]

--- a/advanced_alchemy/repository/memory/_sync.py
+++ b/advanced_alchemy/repository/memory/_sync.py
@@ -272,11 +272,19 @@ class SQLAlchemySyncMockRepository(Generic[ModelT]):
             match_fields = [match_fields]
         return match_fields
 
-    def _list_and_count_basic(self, *filters: FilterTypes, **kwargs: Any) -> tuple[list[ModelT], int]:
+    def _list_and_count_basic(
+        self,
+        *filters: FilterTypes | ColumnElement[bool],
+        **kwargs: Any,
+    ) -> tuple[list[ModelT], int]:
         result = self.list(*filters, **kwargs)
         return result, len(result)
 
-    def _list_and_count_window(self, *filters: FilterTypes, **kwargs: Any) -> tuple[list[ModelT], int]:
+    def _list_and_count_window(
+        self,
+        *filters: FilterTypes | ColumnElement[bool],
+        **kwargs: Any,
+    ) -> tuple[list[ModelT], int]:
         return self._list_and_count_basic(*filters, **kwargs)
 
     def _find_or_raise_not_found(self, id_: Any) -> ModelT:
@@ -417,7 +425,11 @@ class SQLAlchemySyncMockRepository(Generic[ModelT]):
     def upsert_many(self, data: list[ModelT], **_: Any) -> list[ModelT]:
         return [self.upsert(item) for item in data]
 
-    def list_and_count(self, *filters: FilterTypes, **kwargs: Any) -> tuple[list[ModelT], int]:
+    def list_and_count(
+        self,
+        *filters: FilterTypes | ColumnElement[bool],
+        **kwargs: Any,
+    ) -> tuple[list[ModelT], int]:
         return self._list_and_count_basic(*filters, **kwargs)
 
     def filter_collection_by_kwargs(self, collection: CollectionT, /, **kwargs: Any) -> CollectionT:

--- a/advanced_alchemy/repository/memory/_sync.py
+++ b/advanced_alchemy/repository/memory/_sync.py
@@ -418,7 +418,10 @@ class SQLAlchemySyncMockRepository(Generic[ModelT]):
         return deleted
 
     def upsert(self, data: ModelT, **_: Any) -> ModelT:
-        return self.update(data) if data in self.__collection__() else self.add(data)
+        # sourcery skip: assign-if-exp, reintroduce-else
+        if data in self.__collection__():
+            return self.update(data)
+        return self.add(data)
 
     def upsert_many(self, data: list[ModelT], **_: Any) -> list[ModelT]:
         return [self.upsert(item) for item in data]

--- a/advanced_alchemy/service/_async.py
+++ b/advanced_alchemy/service/_async.py
@@ -63,7 +63,7 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT]):
 
     async def count(
         self,
-        *filters: FilterTypes,
+        *filters: FilterTypes | ColumnElement[bool],
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         **kwargs: Any,
     ) -> int:
@@ -176,7 +176,7 @@ class SQLAlchemyAsyncRepositoryReadService(Generic[ModelT]):
 
     async def list_and_count(
         self,
-        *filters: FilterTypes,
+        *filters: FilterTypes | ColumnElement[bool],
         auto_expunge: bool | None = None,
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         force_basic_query_mode: bool | None = None,

--- a/advanced_alchemy/service/_sync.py
+++ b/advanced_alchemy/service/_sync.py
@@ -67,7 +67,7 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT]):
 
     def count(
         self,
-        *filters: FilterTypes,
+        *filters: FilterTypes | ColumnElement[bool],
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         **kwargs: Any,
     ) -> int:
@@ -180,7 +180,7 @@ class SQLAlchemySyncRepositoryReadService(Generic[ModelT]):
 
     def list_and_count(
         self,
-        *filters: FilterTypes,
+        *filters: FilterTypes | ColumnElement[bool],
         auto_expunge: bool | None = None,
         statement: Select[tuple[ModelT]] | StatementLambdaElement | None = None,
         force_basic_query_mode: bool | None = None,


### PR DESCRIPTION
The `ColumnElement[bool]` type was missing from the service `count` and `list_and_count` method.