### PR TITLE
fix: add Alembic template for Encrypted String

### DIFF
--- a/advanced_alchemy/alembic/templates/asyncio/script.py.mako
+++ b/advanced_alchemy/alembic/templates/asyncio/script.py.mako
@@ -24,6 +24,8 @@ __all__ = ["downgrade", "upgrade", "schema_upgrades", "schema_downgrades", "data
 sa.GUID = GUID
 sa.DateTimeUTC = DateTimeUTC
 sa.ORA_JSONB = ORA_JSONB
+sa.EncryptedString = EncryptedString
+sa.EncryptedText = EncryptedText
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}

--- a/advanced_alchemy/alembic/templates/sync/script.py.mako
+++ b/advanced_alchemy/alembic/templates/sync/script.py.mako
@@ -24,6 +24,8 @@ __all__ = ["downgrade", "upgrade", "schema_upgrades", "schema_downgrades", "data
 sa.GUID = GUID
 sa.DateTimeUTC = DateTimeUTC
 sa.ORA_JSONB = ORA_JSONB
+sa.EncryptedString = EncryptedString
+sa.EncryptedText = EncryptedText
 
 # revision identifiers, used by Alembic.
 revision: str = ${repr(up_revision)}

--- a/advanced_alchemy/types/encrypted_string.py
+++ b/advanced_alchemy/types/encrypted_string.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import base64
 import contextlib
+import os
 from typing import TYPE_CHECKING, Any, Callable
 
 from sqlalchemy import String, Text, TypeDecorator
@@ -98,7 +99,7 @@ class EncryptedString(TypeDecorator):
 
     def __init__(
         self,
-        key: str | bytes | Callable[[], str | bytes],
+        key: str | bytes | Callable[[], str | bytes] = os.urandom(32),
         backend: type[EncryptionBackend] = FernetBackend,
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
Updates the alembic template so that it will properly generate the DDL for Encrypted types.

Without the default key, the Alembic templates will complain- even though the key is not actually needed to deploy the DDLs