### PR TITLE
fix: adjusted type hints for `UUID` when `uuid-utils` is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ offering features such as:
 - Custom-built alembic configuration and CLI with optional framework integration
 - Utility base classes with audit columns, primary keys and utility functions
 - Optimized JSON types including a custom JSON type for Oracle.
+- Integrated support for UUID6 and UUID7 using [`uuid-utils`](https://github.com/aminalaee/uuid-utils) (install with the `uuid` extra)
 
 - Pre-configured base classes with audit columns UUID or Big Integer primary keys and
   a [sentinel column](https://docs.sqlalchemy.org/en/20/core/connections.html#configuring-sentinel-columns).

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -191,7 +191,7 @@ def create_registry(
         from pydantic import AnyHttpUrl, AnyUrl, EmailStr, Json
 
         type_annotation_map.update(  # pyright: ignore[reportCallIssue]
-            {EmailStr: String, AnyUrl: String, AnyHttpUrl: String, Json: JsonB}, # pyright: ignore[reportArgumentType]
+            {EmailStr: String, AnyUrl: String, AnyHttpUrl: String, Json: JsonB},  # pyright: ignore[reportArgumentType]
         )
     with contextlib.suppress(ImportError):
         from msgspec import Struct

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -190,8 +190,8 @@ def create_registry(
     with contextlib.suppress(ImportError):
         from pydantic import AnyHttpUrl, AnyUrl, EmailStr, Json
 
-        type_annotation_map.update(  # pyright: ignore[reportCallIssues,reportArgumentType]
-            {EmailStr: String, AnyUrl: String, AnyHttpUrl: String, Json: JsonB},
+        type_annotation_map.update(  # pyright: ignore[reportCallIssue]
+            {EmailStr: String, AnyUrl: String, AnyHttpUrl: String, Json: JsonB}, # pyright: ignore[reportArgumentType]
         )
     with contextlib.suppress(ImportError):
         from msgspec import Struct

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -21,8 +21,8 @@ from sqlalchemy.orm import (
 
 from advanced_alchemy.types import GUID, BigIntIdentity, DateTimeUTC, JsonB
 
-if UUID_UTILS_INSTALLED := find_spec("uuid_utils") and not TYPE_CHECKING:
-    from uuid_utils import UUID, uuid4, uuid6, uuid7
+if (UUID_UTILS_INSTALLED := find_spec("uuid_utils")) and not TYPE_CHECKING:
+    from uuid_utils import UUID, uuid4, uuid6, uuid7  # pyright: ignore[reportMissingImports]
 else:
     from uuid import UUID, uuid4  # type: ignore[assignment]
 

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import contextlib
 import re
 from datetime import date, datetime, timezone
-from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeVar, runtime_checkable
 
 from sqlalchemy import Date, MetaData, Sequence, String
@@ -19,9 +18,9 @@ from sqlalchemy.orm import (
     registry,
 )
 
-from advanced_alchemy.types import GUID, BigIntIdentity, DateTimeUTC, JsonB
+from advanced_alchemy.types import GUID, UUID_UTILS_INSTALLED, BigIntIdentity, DateTimeUTC, JsonB
 
-if (UUID_UTILS_INSTALLED := find_spec("uuid_utils")) and not TYPE_CHECKING:
+if UUID_UTILS_INSTALLED and not TYPE_CHECKING:
     from uuid_utils import UUID, uuid4, uuid6, uuid7  # pyright: ignore[reportMissingImports]
 else:
     from uuid import UUID, uuid4  # type: ignore[assignment]
@@ -191,7 +190,9 @@ def create_registry(
     with contextlib.suppress(ImportError):
         from pydantic import AnyHttpUrl, AnyUrl, EmailStr, Json
 
-        type_annotation_map.update({EmailStr: String, AnyUrl: String, AnyHttpUrl: String, Json: JsonB})
+        type_annotation_map.update(  # pyright: ignore[reportCallIssues,reportArgumentType]
+            {EmailStr: String, AnyUrl: String, AnyHttpUrl: String, Json: JsonB},
+        )
     with contextlib.suppress(ImportError):
         from msgspec import Struct
 

--- a/advanced_alchemy/base.py
+++ b/advanced_alchemy/base.py
@@ -21,8 +21,7 @@ from sqlalchemy.orm import (
 
 from advanced_alchemy.types import GUID, BigIntIdentity, DateTimeUTC, JsonB
 
-UUID_UTILS_INSTALLED = find_spec("uuid_utils")
-if UUID_UTILS_INSTALLED:
+if UUID_UTILS_INSTALLED := find_spec("uuid_utils") and not TYPE_CHECKING:
     from uuid_utils import UUID, uuid4, uuid6, uuid7
 else:
     from uuid import UUID, uuid4  # type: ignore[assignment]

--- a/advanced_alchemy/extensions/litestar/plugins/init/plugin.py
+++ b/advanced_alchemy/extensions/litestar/plugins/init/plugin.py
@@ -65,12 +65,12 @@ class SQLAlchemyInitPlugin(InitPluginProtocol, CLIPluginProtocol, _slots_base.Sl
             app_config: The :class:`AppConfig <.config.app.AppConfig>` instance.
         """
         with contextlib.suppress(ImportError):
-            from asyncpg.pgproto import pgproto
+            from asyncpg.pgproto import pgproto  # pyright: ignore[reportMissingImports]
 
             signature_namespace_values.update({"pgproto.UUID": pgproto.UUID})
             app_config.type_encoders = {pgproto.UUID: str, **(app_config.type_encoders or {})}
         with contextlib.suppress(ImportError):
-            from uuid_utils import UUID
+            from uuid_utils import UUID  # pyright: ignore[reportMissingImports]
 
             signature_namespace_values.update({"UUID": UUID})
             app_config.type_encoders = {

--- a/advanced_alchemy/extensions/sanic.py
+++ b/advanced_alchemy/extensions/sanic.py
@@ -44,7 +44,7 @@ class SanicAdvancedAlchemy(Extension, Generic[EngineT, SessionT, SessionMakerT])
         *,
         sqlalchemy_config: SQLAlchemyAsyncConfig,
         autocommit: CommitStrategy | None = None,
-        counters: Default | bool = _default,
+        counters: Default | bool = _default,  # pyright: ignore[reportInvalidTypeForm]
         session_maker_key: str = "sessionmaker",
         engine_key: str = "engine",
         session_key: str = "session",
@@ -56,7 +56,7 @@ class SanicAdvancedAlchemy(Extension, Generic[EngineT, SessionT, SessionMakerT])
         *,
         sqlalchemy_config: SQLAlchemySyncConfig,
         autocommit: CommitStrategy | None = None,
-        counters: Default | bool = _default,
+        counters: Default | bool = _default,  # pyright: ignore[reportInvalidTypeForm]
         session_maker_key: str = "sessionmaker",
         engine_key: str = "engine",
         session_key: str = "session",
@@ -70,7 +70,7 @@ class SanicAdvancedAlchemy(Extension, Generic[EngineT, SessionT, SessionMakerT])
         *,
         sqlalchemy_config: SQLAlchemySyncConfig | SQLAlchemyAsyncConfig,
         autocommit: CommitStrategy | None = None,
-        counters: Default | bool = _default,
+        counters: Default | bool = _default,  # pyright: ignore[reportInvalidTypeForm]
         session_maker_key: str = "sessionmaker",
         engine_key: str = "engine",
         session_key: str = "session",

--- a/advanced_alchemy/service/typing.py
+++ b/advanced_alchemy/service/typing.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from typing import Any, TypeAlias, TypeVar
 
 from advanced_alchemy.filters import FilterTypes
-from advanced_alchemy.repository.typing import ModelT
+from advanced_alchemy.repository.typing import ModelT  # noqa: TCH001
 
-ModelDictT: TypeAlias = dict[str, Any] | ModelT
-ModelDictListT: TypeAlias = list[ModelT | dict[str, Any]] | list[dict[str, Any]]
+ModelDictT: TypeAlias = "dict[str, Any] | ModelT"
+ModelDictListT: TypeAlias = "list[ModelT | dict[str, Any]] | list[dict[str, Any]]"
 FilterTypeT = TypeVar("FilterTypeT", bound=FilterTypes)

--- a/advanced_alchemy/types/__init__.py
+++ b/advanced_alchemy/types/__init__.py
@@ -6,7 +6,7 @@ from advanced_alchemy.types.encrypted_string import (
     FernetBackend,
     PGCryptoBackend,
 )
-from advanced_alchemy.types.guid import GUID
+from advanced_alchemy.types.guid import GUID, UUID_UTILS_INSTALLED
 from advanced_alchemy.types.identity import BigIntIdentity
 from advanced_alchemy.types.json import ORA_JSONB, JsonB
 
@@ -21,4 +21,5 @@ __all__ = (
     "EncryptionBackend",
     "PGCryptoBackend",
     "FernetBackend",
+    "UUID_UTILS_INSTALLED",
 )

--- a/advanced_alchemy/types/guid.py
+++ b/advanced_alchemy/types/guid.py
@@ -13,7 +13,7 @@ from typing_extensions import Buffer
 if UUID_UTILS_INSTALLED := find_spec("uuid_utils") and not TYPE_CHECKING:
     from uuid_utils import UUID
 else:
-    from uuid import UUID  # type: ignore[no-redef,assignment]
+    from uuid import UUID  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Dialect

--- a/advanced_alchemy/types/guid.py
+++ b/advanced_alchemy/types/guid.py
@@ -10,8 +10,8 @@ from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.types import BINARY, CHAR, TypeDecorator
 from typing_extensions import Buffer
 
-if UUID_UTILS_INSTALLED := find_spec("uuid_utils") and not TYPE_CHECKING:
-    from uuid_utils import UUID
+if (UUID_UTILS_INSTALLED := find_spec("uuid_utils")) and not TYPE_CHECKING:
+    from uuid_utils import UUID  # pyright: ignore[reportMissingImports]
 else:
     from uuid import UUID  # type: ignore[assignment]
 

--- a/advanced_alchemy/types/guid.py
+++ b/advanced_alchemy/types/guid.py
@@ -8,14 +8,12 @@ from sqlalchemy.dialects.mssql import UNIQUEIDENTIFIER as MSSQL_UNIQUEIDENTIFIER
 from sqlalchemy.dialects.oracle import RAW as ORA_RAW
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.types import BINARY, CHAR, TypeDecorator
+from typing_extensions import Buffer
 
-if UUID_UTILS_INSTALLED := find_spec("uuid_utils"):
-    import uuid as core_uuid
-
-    import uuid_utils as uuid
+if UUID_UTILS_INSTALLED := find_spec("uuid_utils") and not TYPE_CHECKING:
+    from uuid_utils import UUID
 else:
-    import uuid  # type: ignore[no-redef,unused-ignore]
-    import uuid as core_uuid
+    from uuid import UUID  # type: ignore[no-redef,assignment]
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Dialect
@@ -37,8 +35,8 @@ class GUID(TypeDecorator):
     cache_ok = True
 
     @property
-    def python_type(self) -> type[uuid.UUID | core_uuid.UUID]:
-        return uuid.UUID
+    def python_type(self) -> type[UUID]:
+        return UUID
 
     def __init__(self, *args: Any, binary: bool = True, **kwargs: Any) -> None:
         self.binary = binary
@@ -56,7 +54,7 @@ class GUID(TypeDecorator):
 
     def process_bind_param(
         self,
-        value: bytes | str | uuid.UUID | core_uuid.UUID | None,
+        value: bytes | str | UUID | None,
         dialect: Dialect,
     ) -> bytes | str | None:
         if value is None:
@@ -72,31 +70,31 @@ class GUID(TypeDecorator):
 
     def process_result_value(
         self,
-        value: bytes | str | uuid.UUID | core_uuid.UUID | None,
+        value: bytes | str | UUID | None,
         dialect: Dialect,
-    ) -> uuid.UUID | core_uuid.UUID | None:
+    ) -> UUID | None:
         if value is None:
             return value
-        if isinstance(value, (uuid.UUID, core_uuid.UUID)):
-            return value
+        if value.__class__.__name__ == "UUID":
+            return cast("UUID", value)
         if dialect.name == "spanner+spanner":
-            return uuid.UUID(bytes=b64decode(value))
+            return UUID(bytes=b64decode(cast("str | Buffer", value)))
         if self.binary:
-            return uuid.UUID(bytes=cast("bytes", value))
-        return uuid.UUID(hex=cast("str", value))
+            return UUID(bytes=cast("bytes", value))
+        return UUID(hex=cast("str", value))
 
     @staticmethod
-    def to_uuid(value: Any) -> uuid.UUID | core_uuid.UUID | None:
-        if isinstance(value, (uuid.UUID, core_uuid.UUID)) or value is None:
-            return value
+    def to_uuid(value: Any) -> UUID | None:
+        if value.__class__.__name__ == "UUID" or value is None:
+            return cast("UUID | None", value)
         try:
-            value = uuid.UUID(hex=value)
+            value = UUID(hex=value)
         except (TypeError, ValueError):
-            value = uuid.UUID(bytes=value)
-        return cast("uuid.UUID | None", value)
+            value = UUID(bytes=value)
+        return cast("UUID | None", value)
 
     def compare_values(self, x: Any, y: Any) -> bool:
         """Compare two values for equality."""
-        if isinstance(x, (uuid.UUID, core_uuid.UUID)) and isinstance(y, (uuid.UUID, core_uuid.UUID)):
-            return x.bytes == y.bytes
+        if x.__class__.__name__ == "UUID" and y.__class__.__name__ == "UUID":
+            return cast("bool", x.bytes == y.bytes)
         return cast("bool", x == y)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "docs", "extensions", "linting", "test", "uuid"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:6861d6001ce826be7575df158f9ba4bd1406a6068b1f72e7071ead96d99a9618"
+content_hash = "sha256:8c65cfa8dac253698e4e04ea44628201ec9aef64b597df8cf7999be1d4323016"
 
 [[package]]
 name = "aiofiles"
@@ -2571,6 +2571,20 @@ files = [
     {file = "pyodbc-5.1.0-cp39-cp39-win32.whl", hash = "sha256:96b2a8dc27693a517e3aad3944a7faa8be95d40d7ec1eda51a1885162eedfa33"},
     {file = "pyodbc-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:e738c5eedb4a0cbab20cc008882f49b106054499db56864057c2530ff208cf32"},
     {file = "pyodbc-5.1.0.tar.gz", hash = "sha256:397feee44561a6580be08cedbe986436859563f4bb378f48224655c8e987ea60"},
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.350"
+requires_python = ">=3.7"
+summary = "Command line wrapper for pyright"
+groups = ["linting"]
+dependencies = [
+    "nodeenv>=1.6.0",
+]
+files = [
+    {file = "pyright-1.1.350-py3-none-any.whl", hash = "sha256:f1dde6bcefd3c90aedbe9dd1c573e4c1ddbca8c74bf4fa664dd3b1a599ac9a66"},
+    {file = "pyright-1.1.350.tar.gz", hash = "sha256:a8ba676de3a3737ea4d8590604da548d4498cc5ee9ee00b1a403c6db987916c6"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,15 +98,15 @@ extensions = [
   "flask-sqlalchemy>=3.1.1",
 ]
 linting = [
-  "pre-commit>=3.4.0",
-  "black>=23.7.0",
-  "mypy>=1.5.1",
-  "ruff>=0.0.287",
-  "asyncpg-stubs",
-  "types-pytest-lazy-fixture",
-  "types-click",
-  "types-pyyaml",
-  "pyright>=1.1.350",
+    "pre-commit>=3.4.0",
+    "black>=23.7.0",
+    "mypy>=1.5.1",
+    "ruff>=0.0.287",
+    "asyncpg-stubs",
+    "types-pytest-lazy-fixture",
+    "types-click",
+    "types-pyyaml",
+    "pyright>=1.1.350",
 ]
 test = [
   "pytest>=7.4.1,<8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ linting = [
   "types-pytest-lazy-fixture",
   "types-click",
   "types-pyyaml",
+  "pyright>=1.1.350",
 ]
 test = [
   "pytest>=7.4.1,<8.0.0",
@@ -293,6 +294,8 @@ module = [
   "pytest_docker.*",
   "googleapiclient",
   "googleapiclient.*",
+  "uuid_utils",
+  "uuid_utils.*",
 ]
 
 [[tool.mypy.overrides]]
@@ -312,6 +315,19 @@ disable_error_code = "no-untyped-call"
 disallow_untyped_decorators = false
 module = "advanced_alchemy.extensions.sanic"
 warn_unused_ignores = false
+
+[tool.pyright]
+disableBytesTypePromotions = true
+exclude = [
+  "docs",
+  "tests/unit/test_extensions",
+  "tests/unit/test_repository.py",
+  "tests/helpers.py",
+  "tests/docker_service_fixtures.py",
+]
+include = ["advanced_alchemy", "tests"]
+pythonVersion = "3.8"
+reportUnnecessaryTypeIgnoreComments = true
 
 [tool.unasyncd]
 add_editors_note = true


### PR DESCRIPTION
This PR addresses an issue with type hints when `uuid-utils` is not installed.

```shell
❯ pdm run pip uninstall uuid-utils
Found existing installation: uuid_utils 0.6.1
Uninstalling uuid_utils-0.6.1:
  Would remove:
    .../.venv/lib/python3.12/site-packages/uuid_utils-0.6.1.dist-info/*
    .../.venv/lib/python3.12/site-packages/uuid_utils/*
Proceed (Y/n)? y
  Successfully uninstalled uuid_utils-0.6.1
❯ pdm run pyright -p pyproject.toml advanced_alchemy/base.py
0 errors, 0 warnings, 0 informations 
❯ pdm run pyright -p pyproject.toml advanced_alchemy/types/guid.py
0 errors, 0 warnings, 0 informations 
```