### PR TITLE
fix: moved function breaks Litestar imports.

### DIFF
--- a/advanced_alchemy/repository/_util.py
+++ b/advanced_alchemy/repository/_util.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+from advanced_alchemy.exceptions import wrap_sqlalchemy_exception as _wrap_sqlalchemy_exception
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import InstrumentedAttribute
 
     from advanced_alchemy.base import ModelProtocol
     from advanced_alchemy.repository.typing import ModelT
+
+# NOTE: For backward compatibility with Litestar - this is imported from here within the litestar codebase.
+wrap_sqlalchemy_exception = _wrap_sqlalchemy_exception
 
 
 def get_instrumented_attr(model: type[ModelProtocol], key: str | InstrumentedAttribute) -> InstrumentedAttribute:

--- a/tests/unit/test_extensions/test_litestar/test_litestar_re_exports.py
+++ b/tests/unit/test_extensions/test_litestar/test_litestar_re_exports.py
@@ -1,0 +1,10 @@
+# ruff: noqa: F401
+
+
+def test_repository_re_exports() -> None:
+    from litestar.contrib.sqlalchemy import types
+    from litestar.contrib.sqlalchemy.repository import (
+        SQLAlchemyAsyncRepository,
+        SQLAlchemySyncRepository,
+        wrap_sqlalchemy_exception,
+    )


### PR DESCRIPTION
`wrap_sqlalchemy_exception()` was moved from `repository._util` to `exceptions`, however it is still imported downstream by litestar from the original location.

This PR adds an alias to the function in `repository._util` for backward compat with litestar.

[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Jolt's Code of Conduct](https://github.com/jolt-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Jolt's contribution guidelines](https://github.com/jolt-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- 

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- 
